### PR TITLE
Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,28 @@
+FROM debian:10.4 
+
+ARG UNAME=user
+ARG UID=1000
+ARG GID=1000
+
+COPY checksums.md5 .
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt update && \
+    apt install -y build-essential cmake wget unzip && \
+    rm -rf /var/lib/apt/lists && \
+    wget "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/8-2019q3/RC1.1/gcc-arm-none-eabi-8-2019-q3-update-linux.tar.bz2" && \
+    wget "https://www.nordicsemi.com/-/media/Software-and-other-downloads/SDKs/nRF5/Binaries/nRF5SDK153059ac345.zip" && \
+    md5sum -c checksums.md5 && \
+    tar -xf gcc-arm-none-eabi-8-2019-q3-update-linux.tar.bz2 -C /opt && \
+    rm gcc-arm-none-eabi-8-2019-q3-update-linux.tar.bz2 && \
+    unzip nRF5SDK153059ac345.zip -d /opt && \
+    rm nRF5SDK153059ac345.zip
+
+COPY entrypoint.sh .
+
+RUN groupadd -g $GID -o $UNAME
+RUN useradd -m -u $UID -g $GID -o -s /bin/bash $UNAME
+USER $UNAME
+
+ENTRYPOINT /entrypoint.sh

--- a/docker/checksums.md5
+++ b/docker/checksums.md5
@@ -1,0 +1,2 @@
+6341f11972dac8de185646d0fbd73bfc  gcc-arm-none-eabi-8-2019-q3-update-linux.tar.bz2
+46a8c9cd4b5d7ee4c5142e8fae3444c4  nRF5SDK153059ac345.zip

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,22 @@
+#! /bin/bash
+
+cd /pinetime
+mkdir build
+cd build
+
+if [ $USE_OPENOCD = 1 ]
+then
+	cmake -DARM_NONE_EABI_TOOLCHAIN_PATH=/opt/gcc-arm-none-eabi-8-2019-q3-update \
+			-DNRF5_SDK_PATH=/opt/nRF5_SDK_15.3.0_59ac345\
+			-DUSE_OPENOCD=1 \
+			-DGDB_CLIENT_TARGET_REMOTE=$GDB_CLIENT \
+			../
+else
+	cmake -DARM_NONE_EABI_TOOLCHAIN_PATH=/opt/gcc-arm-none-eabi-8-2019-q3-update \
+			-DNRF5_SDK_PATH=/opt/nRF5_SDK_15.3.0_59ac345\
+			-DUSE_JLINK=1 \
+			-DGDB_CLIENT_TARGET_REMOTE=$GDB_CLIENT \
+			../
+fi
+
+make -j pinetime-app

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -1,0 +1,57 @@
+#! /bin/bash
+
+usage() { echo "
+Usage: $0 [OPTIONS]
+
+-j Use JLink
+-o Use OpenOCD
+-f Force image rebuild
+-c <string> Specify GDB Client e.g '/dev/ttyACM0'" 1>&2;
+	exit 1;}
+
+FORCE_REBUILD=0
+while getopts "jofc:" option; do
+case ${option} in
+	j )
+		USE_JLINK=1
+	;;
+	o )
+		USE_OPENOCD=1
+	;;
+	c )
+		GDB_CLIENT=${OPTARG}
+	;;
+	f )
+		FORCE_REBUILD=1
+	;;
+	\? )
+		usage
+	;;
+esac
+done
+
+docker container ls 1>&2 2>/dev/null
+if [ $? -gt 0 ]
+then
+	echo "
+	You do not have access to the docker daemon.
+	Make sure your user is a member of the docker group
+	or run this script as root
+	" 
+	exit
+fi
+
+docker image ls | grep "gcc-nrf-arm"
+if [ $FORCE_REBUILD ]  || [ $? -gt 0 ]
+then
+	echo "Building docker image"
+	docker build --build-arg UID=$(id -u) --build-arg GID=$(id -g) ./docker -t gcc-nrf-arm:2019q3
+fi
+
+
+docker run --rm \
+	-v `pwd`:/pinetime \
+	-e USE_JLINK=${USE_JLINK:-0} \
+	-e USE_OPENOCD=${USE_OPENOCD:-0} \
+	-e GDB_CLIENT=$GDB_CLIENT \
+	gcc-nrf-arm:2019q3


### PR DESCRIPTION
The Docker image contains the arm gcc toolchain 2019q3
and the NRF SDk 15.3.0_59ac345.


The build script currently builds the docker Image if not present.
Then it starts the container with the current directory mounted
which then runs cmake and make.

Flashing with this image does not work yet but that should be possible.