### PR TITLE
Workaround for TWI driver freeze

### DIFF
--- a/src/drivers/Cst816s.cpp
+++ b/src/drivers/Cst816s.cpp
@@ -37,7 +37,9 @@ void Cst816S::Init() {
 Cst816S::TouchInfos Cst816S::GetTouchInfo() {
   Cst816S::TouchInfos info;
 
-  twiMaster.Read(twiAddress, 0, touchData, 63);
+  auto ret = twiMaster.Read(twiAddress, 0, touchData, 63);
+  if(ret != TwiMaster::ErrorCodes::NoError) return {};
+
   auto nbTouchPoints = touchData[2] & 0x0f;
 
 //  uint8_t i = 0;

--- a/src/drivers/Cst816s.h
+++ b/src/drivers/Cst816s.h
@@ -18,13 +18,13 @@ namespace Pinetime {
             LongPress = 0x0C
         };
         struct TouchInfos {
-          uint16_t x;
-          uint16_t y;
-          uint8_t action;
-          uint8_t finger;
-          uint8_t pressure;
-          uint8_t area;
-          Gestures gesture;
+          uint16_t x = 0;
+          uint16_t y = 0;
+          uint8_t action = 0;
+          uint8_t finger = 0;
+          uint8_t pressure = 0;
+          uint8_t area = 0;
+          Gestures gesture = Gestures::None;
           bool isTouch = false;
         };
 

--- a/src/drivers/TwiMaster.h
+++ b/src/drivers/TwiMaster.h
@@ -10,6 +10,7 @@ namespace Pinetime {
       public:
         enum class Modules { TWIM1 };
         enum class Frequencies {Khz100, Khz250, Khz400};
+        enum class ErrorCodes {NoError, TransactionFailed};
         struct Parameters {
           uint32_t frequency;
           uint8_t pinSda;
@@ -19,15 +20,19 @@ namespace Pinetime {
         TwiMaster(const Modules module, const Parameters& params);
 
         void Init();
-        void Read(uint8_t deviceAddress, uint8_t registerAddress, uint8_t* buffer, size_t size);
-        void Write(uint8_t deviceAddress, uint8_t registerAddress, const uint8_t* data, size_t size);
+        ErrorCodes Read(uint8_t deviceAddress, uint8_t registerAddress, uint8_t* buffer, size_t size);
+        ErrorCodes Write(uint8_t deviceAddress, uint8_t registerAddress, const uint8_t* data, size_t size);
 
         void Sleep();
         void Wakeup();
 
       private:
-        void Read(uint8_t deviceAddress, uint8_t* buffer, size_t size, bool stop);
-        void Write(uint8_t deviceAddress, const uint8_t* data, size_t size, bool stop);
+        ErrorCodes ReadWithRetry(uint8_t deviceAddress, uint8_t registerAddress, uint8_t* buffer, size_t size);
+        ErrorCodes WriteWithRetry(uint8_t deviceAddress, uint8_t registerAddress, const uint8_t* data, size_t size);
+
+        ErrorCodes Read(uint8_t deviceAddress, uint8_t* buffer, size_t size, bool stop);
+        ErrorCodes Write(uint8_t deviceAddress, const uint8_t* data, size_t size, bool stop);
+        void FixHwFreezed();
         NRF_TWIM_Type* twiBaseAddress;
         SemaphoreHandle_t mutex;
         const Modules module;
@@ -35,7 +40,8 @@ namespace Pinetime {
         static constexpr uint8_t maxDataSize{8};
         static constexpr uint8_t registerSize{1};
         uint8_t internalBuffer[maxDataSize + registerSize];
-
+        uint32_t txStartedCycleCount = 0;
+        static constexpr uint32_t HwFreezedDelay{161000};
     };
   }
 }


### PR DESCRIPTION
Workaround for bug https://github.com/JF002/Pinetime/issues/79 until a better fix is found.
When the driver is stuck in an infinite loop for more than ~2.5ms, the TWI device is re-init and the transaction is retried.
Read() and Write() return an error code.
