### PR TITLE
Reduced interval where the display shows the previous time on wake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ CMakeFiles/
 **/CMakeCache.txt
 cmake_install.cmake
 Makefile
+build/
 
 # Resulting binary files
 *.a

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -193,7 +193,7 @@ void SystemTask::Work() {
 
     monitor.Process();
     uint32_t systick_counter = nrf_rtc_counter_get(portNRF_RTC_REG);
-    dateTimeController.UpdateTime(nrf_rtc_counter_get(systick_counter));
+    dateTimeController.UpdateTime(systick_counter);
     if(!nrf_gpio_pin_read(pinButton))
       watchdog.Kick();
   }

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -193,7 +193,7 @@ void SystemTask::Work() {
 
     monitor.Process();
     uint32_t systick_counter = nrf_rtc_counter_get(portNRF_RTC_REG);
-    dateTimeController.UpdateTime(nrf_rtc_counter_get(systick_counter);
+    dateTimeController.UpdateTime(nrf_rtc_counter_get(systick_counter));
     if(!nrf_gpio_pin_read(pinButton))
       watchdog.Kick();
   }

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -192,7 +192,8 @@ void SystemTask::Work() {
     }
 
     monitor.Process();
-    dateTimeController.UpdateTime(nrf_rtc_counter_get(portNRF_RTC_REG););
+    uint32_t systick_counter = nrf_rtc_counter_get(portNRF_RTC_REG);
+    dateTimeController.UpdateTime(nrf_rtc_counter_get(systick_counter);
     if(!nrf_gpio_pin_read(pinButton))
       watchdog.Kick();
   }

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -105,8 +105,12 @@ void SystemTask::Work() {
   #pragma clang diagnostic push
   #pragma ide diagnostic ignored "EndlessLoop"
   while(true) {
+
     uint8_t msg;
     if (xQueueReceive(systemTasksMsgQueue, &msg, isSleeping ? 2500 : 1000)) {
+      uint32_t systick_counter = nrf_rtc_counter_get(portNRF_RTC_REG);
+      dateTimeController.UpdateTime(systick_counter);
+      batteryController.Update();
       Messages message = static_cast<Messages >(msg);
       switch(message) {
         case Messages::GoToRunning:
@@ -189,10 +193,6 @@ void SystemTask::Work() {
         bleDiscoveryTimer--;
       }
     }
-
-    uint32_t systick_counter = nrf_rtc_counter_get(portNRF_RTC_REG);
-    dateTimeController.UpdateTime(systick_counter);
-    batteryController.Update();
 
     monitor.Process();
 


### PR DESCRIPTION
Now when you wake up your watch you'll notice the correct time is waiting for you! The display would show the last time displayed for the amount of time it took to start advertising over BLE and wake peripherals. Note that I think the final change should be some restructuring but now the time updating on wakeup isn't annoying.