### PR TITLE
fix error install cmake

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
       # Download and Cache Dependencies
 
       - name: Install cmake
-        uses: lukka/get-cmake@v3.18.0
+        uses: lukka/get-cmake@v3.18.3
 
       - name: Check cache for Embedded Arm Toolchain arm-none-eabi-gcc
         id:   cache-toolchain

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -142,7 +142,7 @@ jobs:
       - name: Upload DFU package
         uses: actions/upload-artifact@v2
         with:
-          name: pinetime-mcuboot-app-dfu.zip
+          name: pinetime-mcuboot-app-dfu
           path: build/src/pinetime-mcuboot-app-dfu/*
 
         #########################################################################################


### PR DESCRIPTION
When installing Cmake you get Error: The `add-path` command is deprecated and will be disabled on November 16th...
And the file pinetime-mcuboot-app-dfu.zip was being generated as pinetime-mcuboot-app-dfu.zip.zip