### PR TITLE
Flash the correct file when running FLASH_pinetime-app with JLink

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -713,7 +713,7 @@ if (USE_JLINK)
             )
     add_custom_target("FLASH_${EXECUTABLE_NAME}"
             DEPENDS ${EXECUTABLE_NAME}
-            COMMAND ${NRFJPROG} --program ${EXECUTABLE_NAME}.hex -f ${NRF_TARGET} --sectorerase
+            COMMAND ${NRFJPROG} --program ${EXECUTABLE_FILE_NAME}.hex -f ${NRF_TARGET} --sectorerase
             COMMAND sleep 0.5s
             COMMAND ${NRFJPROG} --reset -f ${NRF_TARGET}
             COMMENT "flashing ${EXECUTABLE_NAME}.hex"


### PR DESCRIPTION
Without this change it attempts to flash using `pinetime-app.hex` (which doesn't exist) instead of `pinetime-app-${version}.hex` (which does exist).