### PR TITLE
Add docker hub image, and other tweaks to docker image and documentation

### DIFF
--- a/doc/buildWithDocker.md
+++ b/doc/buildWithDocker.md
@@ -3,7 +3,7 @@ There are [Docker images (Dockerfile)](../docker) containing the build environme
 
 ## Using the image from Docker Hub
 
-The image is avaiable via Docker Hub for both the amd64 and arm64v8 architectures at via [pfeerick/infinitime-build](https://hub.docker.com/repository/docker/pfeerick/infinitime-build). 
+The image is avaiable via Docker Hub for both the amd64 and arm64v8 architectures at [pfeerick/infinitime-build](https://hub.docker.com/repository/docker/pfeerick/infinitime-build). 
 
 It can be pulled (downloaded) using the following command:
 
@@ -34,7 +34,7 @@ docker run --rm -v <project_root>:/sources --user uid_num:gid_num infinitime-bui
 ## Build the image yourself
 Building the docker images yourself is quite easy. The following commands must be run from the root of the project.
 
-The `PUID` and `PGID` build arguments are used to set the user id and group id for use in the container, meaning you will not need to specify it later unless on a multi-user system, or they change for some reason. Specifying them is not mandatory, as this can be over-ridden at build time via the `--user` flag, but doing so will make it so the command you need to run later is just a bit shorter. In the below examples, they are being set to your current user id and group id automatically, but you can also specify them manually, but they must be specified by number, not by name.
+The `PUID` and `PGID` build arguments are used to set the user and group ids used in the container, meaning you will not need to specify it later unless they change for some reason. Specifying them is not mandatory, as this can be over-ridden at build time via the `--user` flag, but doing so will make the command you need to run later a bit shorter. In the below examples, they are set to your current user id and group id automatically. You can specify them manually, but they must be specified by number, not by name.
 
 If you are running on a AMD64 (x86_64) computer: 
 ```
@@ -46,13 +46,13 @@ If you are running on an ARM64 computer (tested on Raspberry Pi 4 and Pine64 Pin
 docker image build -t infinitime-build --build-arg PUID=$(id -u) --build-arg PGID=$(id -g) docker/arm64v8/
 ```
 
-This operation will take some time. It builds a Docker image based on Ubuntu, install some packages, download the ARM toolchain, the NRF SDK, MCUBoot and adafruit-nrfutil.
+This operation will take some time, as it builds a Docker image based on Ubuntu, installs some required packages, downloads the ARM toolchain, the NRF SDK, MCUBoot and adafruit-nrfutil.
 
 When this is done, a new image named *infinitime-build* is available.
 
 ## Run a container to build the project:
 
-The command to run the container is essentially the same, regardless of if you built it yourself from the dockerfiles, or are using the Docker hub image:
+The command to run the container is essentially the same, regardless of whether you built it yourself from the dockerfiles, or are using the Docker hub image:
 
 ```
 docker run --rm -v <project_root>:/sources infinitime-build

--- a/doc/buildWithDocker.md
+++ b/doc/buildWithDocker.md
@@ -1,17 +1,49 @@
 # Build the project using Docker
-A [Docker image (Dockerfile)](../docker) containing all the build environment is available for X86_64 and AMD64 architectures. This image makes the build of the firmware and the generation of the DFU file for OTA.
+There are [Docker images (Dockerfile)](../docker) containing the build environment for AMD64 (x86_64) and ARM64 architectures. These images make the build of the firmware and the generation of the DFU file for OTA quite easy, as well as preventing clashes with any other toolchains or development environments you may have installed.
 
-## Build the image
-The image is not (yet) available on DockerHub, you need to build it yourself, which is quite easy. The following commands must be run from the root of the project.
+## Using the image from Docker Hub
 
-If you are running on a x86_64 computer : 
+The image is avaiable via Docker Hub for both the amd64 and arm64v8 architectures at via [pfeerick/infinitime-build](https://hub.docker.com/repository/docker/pfeerick/infinitime-build). 
+
+It can be pulled (downloaded) using the following command:
+
 ```
-docker image build -t infinitime-build --build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g) docker/x86_64/
+docker pull pfeerick/infinitime-build
 ```
 
-And if your are running on an ARM64 device (tested on RaspberryPi4 and Pine64 PineBookPro):
+The default `latest` tag *should* automatically identify the correct image architecture, but if for some reason Docker does not, you can specify it manually:
+
+* For AMD64 (x86_64) systems: `docker pull pfeerick/infinitime-build:amd64`
+
+* For ARM64v8 (ARM64/aarch64) systems: `docker pull pfeerick/infinitime-build:arm64v8`
+
+The Docker Hub images are built using 1000:1000 for the user id and group id. If this is different to your user or group ids (run `id -u` and `id -g` to find out what your id values are if you are unsure), you will need to override them via the `--user` parameter in order to prevent permission errors during and after compilation.
+
+The below example will run the container, setting the user and group ids automatically:
+
 ```
-docker image build -t infinitime-build --build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g) docker/arm64/
+docker run --rm -v <project_root>:/sources --user $(id -u):$(id -g) infinitime-build
+```
+
+Or you can specify your user id and group id (by number, not by name) directly:
+
+```
+docker run --rm -v <project_root>:/sources --user uid_num:gid_num infinitime-build
+```
+
+## Build the image yourself
+Building the docker images yourself is quite easy. The following commands must be run from the root of the project.
+
+The `PUID` and `PGID` build arguments are used to set the user id and group id for use in the container, meaning you will not need to specify it later unless on a multi-user system, or they change for some reason. Specifying them is not mandatory, as this can be over-ridden at build time via the `--user` flag, but doing so will make it so the command you need to run later is just a bit shorter. In the below examples, they are being set to your current user id and group id automatically, but you can also specify them manually, but they must be specified by number, not by name.
+
+If you are running on a AMD64 (x86_64) computer: 
+```
+docker image build -t infinitime-build --build-arg PUID=$(id -u) --build-arg PGID=$(id -g) docker/amd64/
+```
+
+If you are running on an ARM64 computer (tested on Raspberry Pi 4 and Pine64 Pinebook Pro):
+```
+docker image build -t infinitime-build --build-arg PUID=$(id -u) --build-arg PGID=$(id -g) docker/arm64v8/
 ```
 
 This operation will take some time. It builds a Docker image based on Ubuntu, install some packages, download the ARM toolchain, the NRF SDK, MCUBoot and adafruit-nrfutil.
@@ -20,9 +52,13 @@ When this is done, a new image named *infinitime-build* is available.
 
 ## Run a container to build the project:
 
+The command to run the container is essentially the same, regardless of if you built it yourself from the dockerfiles, or are using the Docker hub image:
+
 ```
 docker run --rm -v <project_root>:/sources infinitime-build
 ```
+
+This will start a container (removing it when finished), build the firmware and generate the MCUBoot image and DFU file. The output of the build is stored in `<project_root>/built/output`.
 
 Replace *<project_root>* by the path of the root of the project on your computer. For example:
 
@@ -30,4 +66,4 @@ Replace *<project_root>* by the path of the root of the project on your computer
 docker run --rm -v /home/jf/git/PineTime:/sources infinitime-build
 ```
 
-This will start a container, build the firmware and generate the MCUBoot image and the DFU file. The output of the build is stored in **<project_root>/built/output**.
+If you encounter permission errors (due to being logged in as a different user, changed user id, running the docker hub image, etc.), see the `--user` parameter mentioned above in the Docker Hub image section to see if this resolves the issue for you.

--- a/doc/buildWithDocker.md
+++ b/doc/buildWithDocker.md
@@ -22,13 +22,13 @@ The Docker Hub images are built using 1000:1000 for the user id and group id. If
 The below example will run the container, setting the user and group ids automatically:
 
 ```
-docker run --rm -v <project_root>:/sources --user $(id -u):$(id -g) infinitime-build
+docker run --rm -v <project_root>:/sources --user $(id -u):$(id -g) pfeerick/infinitime-build
 ```
 
 Or you can specify your user id and group id (by number, not by name) directly:
 
 ```
-docker run --rm -v <project_root>:/sources --user uid_num:gid_num infinitime-build
+docker run --rm -v <project_root>:/sources --user uid_num:gid_num pfeerick/infinitime-build
 ```
 
 ## Build the image yourself
@@ -52,7 +52,7 @@ When this is done, a new image named *infinitime-build* is available.
 
 ## Run a container to build the project:
 
-The command to run the container is essentially the same, regardless of whether you built it yourself from the dockerfiles, or are using the Docker hub image:
+The command to run the container is essentially the same, regardless of whether you built it yourself from the dockerfiles, or are using the Docker Hub images (use `pfeerick/infinitime-build` instead of `infinitime-build` for the later):
 
 ```
 docker run --rm -v <project_root>:/sources infinitime-build

--- a/docker/amd64/Dockerfile
+++ b/docker/amd64/Dockerfile
@@ -14,10 +14,16 @@ RUN apt-get update -qq \
         wget \
     && rm -rf /var/cache/apt/* /var/lib/apt/lists/*
 
-RUN wget -q https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz -O - | tar -xj -C /opt/
-RUN wget -q https://developer.nordicsemi.com/nRF5_SDK/nRF5_SDK_v15.x.x/nRF5_SDK_15.3.0_59ac345.zip && unzip -q nRF5_SDK_15.3.0_59ac345.zip -d /opt/ && rm nRF5_SDK_15.3.0_59ac345.zip
+RUN wget -q https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz \
+  && tar -xjf gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz -C /opt \
+  && rm gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz
 
-RUN git clone https://github.com/JuulLabs-OSS/mcuboot.git /opt/mcuboot && pip3 install -r /opt/mcuboot/scripts/requirements.txt
+RUN wget -q https://developer.nordicsemi.com/nRF5_SDK/nRF5_SDK_v15.x.x/nRF5_SDK_15.3.0_59ac345.zip  \
+  && unzip -q nRF5_SDK_15.3.0_59ac345.zip -d /opt/ && rm nRF5_SDK_15.3.0_59ac345.zip
+
+RUN git clone https://github.com/JuulLabs-OSS/mcuboot.git /opt/mcuboot \
+  && pip3 install -r /opt/mcuboot/scripts/requirements.txt
+
 RUN pip3 install adafruit-nrfutil
 
 ARG PUID=1000

--- a/docker/amd64/Dockerfile
+++ b/docker/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM amd64/ubuntu:18.04
 
 ARG USER_ID
 ARG GROUP_ID

--- a/docker/amd64/Dockerfile
+++ b/docker/amd64/Dockerfile
@@ -1,6 +1,19 @@
 FROM amd64/ubuntu:18.04
 
-RUN apt-get update -qq && apt-get install -y wget unzip cmake make build-essential git python3 python3-pip
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -qq \
+    && apt-get install -y \ 
+        build-essential \
+        cmake \
+        git \
+        make \
+        python3 \
+        python3-pip \
+        tar \
+        unzip \
+        wget \
+    && rm -rf /var/cache/apt/* /var/lib/apt/lists/*
+
 RUN wget -q https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz -O - | tar -xj -C /opt/
 RUN wget -q https://developer.nordicsemi.com/nRF5_SDK/nRF5_SDK_v15.x.x/nRF5_SDK_15.3.0_59ac345.zip && unzip -q nRF5_SDK_15.3.0_59ac345.zip -d /opt/ && rm nRF5_SDK_15.3.0_59ac345.zip
 

--- a/docker/amd64/Dockerfile
+++ b/docker/amd64/Dockerfile
@@ -1,11 +1,5 @@
 FROM amd64/ubuntu:18.04
 
-ARG USER_ID
-ARG GROUP_ID
-
-RUN addgroup --gid $GROUP_ID user
-RUN adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID user
-
 RUN apt-get update -qq && apt-get install -y wget unzip cmake make build-essential git python3 python3-pip
 RUN wget -q https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz -O - | tar -xj -C /opt/
 RUN wget -q https://developer.nordicsemi.com/nRF5_SDK/nRF5_SDK_v15.x.x/nRF5_SDK_15.3.0_59ac345.zip && unzip -q nRF5_SDK_15.3.0_59ac345.zip -d /opt/ && rm nRF5_SDK_15.3.0_59ac345.zip
@@ -13,5 +7,9 @@ RUN wget -q https://developer.nordicsemi.com/nRF5_SDK/nRF5_SDK_v15.x.x/nRF5_SDK_
 RUN git clone https://github.com/JuulLabs-OSS/mcuboot.git /opt/mcuboot && pip3 install -r /opt/mcuboot/scripts/requirements.txt
 RUN pip3 install adafruit-nrfutil
 
-USER user
+ARG PUID=1000
+ARG PGID=1000
+RUN groupadd --system --gid $PGID infinitime && useradd --system --uid $PUID --gid $PGID infinitime
+
+USER infinitime:infinitime
 CMD ["/sources/docker/build.sh"]

--- a/docker/arm64v8/Dockerfile
+++ b/docker/arm64v8/Dockerfile
@@ -1,6 +1,22 @@
 FROM arm64v8/ubuntu:18.04
 
-RUN apt-get update -qq && apt-get install -y wget unzip cmake make build-essential git python3 python3-pip libffi-dev libssl-dev python3-dev
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -qq \
+    && apt-get install -y \ 
+        build-essential \
+        cmake \
+        git \
+        libffi-dev \
+        libssl-dev \
+        make \
+        python3 \
+        python3-dev \
+        python3-pip \
+        tar \
+        unzip \
+        wget \
+    && rm -rf /var/cache/apt/* /var/lib/apt/lists/*
+
 RUN wget -q https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-aarch64-linux.tar.bz2 -O - | tar -xj -C /opt/
 RUN wget -q https://developer.nordicsemi.com/nRF5_SDK/nRF5_SDK_v15.x.x/nRF5_SDK_15.3.0_59ac345.zip && unzip -q nRF5_SDK_15.3.0_59ac345.zip -d /opt/ && rm nRF5_SDK_15.3.0_59ac345.zip
 

--- a/docker/arm64v8/Dockerfile
+++ b/docker/arm64v8/Dockerfile
@@ -17,10 +17,16 @@ RUN apt-get update -qq \
         wget \
     && rm -rf /var/cache/apt/* /var/lib/apt/lists/*
 
-RUN wget -q https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-aarch64-linux.tar.bz2 -O - | tar -xj -C /opt/
-RUN wget -q https://developer.nordicsemi.com/nRF5_SDK/nRF5_SDK_v15.x.x/nRF5_SDK_15.3.0_59ac345.zip && unzip -q nRF5_SDK_15.3.0_59ac345.zip -d /opt/ && rm nRF5_SDK_15.3.0_59ac345.zip
+RUN wget -q https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-aarch64-linux.tar.bz2 \
+  && tar -xjf gcc-arm-none-eabi-9-2020-q2-update-aarch64-linux.tar.bz2 -C /opt \
+  && rm gcc-arm-none-eabi-9-2020-q2-update-aarch64-linux.tar.bz2
+
+RUN wget -q https://developer.nordicsemi.com/nRF5_SDK/nRF5_SDK_v15.x.x/nRF5_SDK_15.3.0_59ac345.zip \
+  && unzip -q nRF5_SDK_15.3.0_59ac345.zip -d /opt/ \
+  && rm nRF5_SDK_15.3.0_59ac345.zip
 
 RUN git clone https://github.com/JuulLabs-OSS/mcuboot.git /opt/mcuboot && pip3 install -r /opt/mcuboot/scripts/requirements.txt
+
 RUN pip3 install adafruit-nrfutil
 
 ARG PUID=1000

--- a/docker/arm64v8/Dockerfile
+++ b/docker/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM arm64v8/ubuntu:18.04
 
 ARG USER_ID
 ARG GROUP_ID

--- a/docker/arm64v8/Dockerfile
+++ b/docker/arm64v8/Dockerfile
@@ -1,11 +1,5 @@
 FROM arm64v8/ubuntu:18.04
 
-ARG USER_ID
-ARG GROUP_ID
-
-RUN addgroup --gid $GROUP_ID user
-RUN adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID user
-
 RUN apt-get update -qq && apt-get install -y wget unzip cmake make build-essential git python3 python3-pip libffi-dev libssl-dev python3-dev
 RUN wget -q https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-aarch64-linux.tar.bz2 -O - | tar -xj -C /opt/
 RUN wget -q https://developer.nordicsemi.com/nRF5_SDK/nRF5_SDK_v15.x.x/nRF5_SDK_15.3.0_59ac345.zip && unzip -q nRF5_SDK_15.3.0_59ac345.zip -d /opt/ && rm nRF5_SDK_15.3.0_59ac345.zip
@@ -13,5 +7,9 @@ RUN wget -q https://developer.nordicsemi.com/nRF5_SDK/nRF5_SDK_v15.x.x/nRF5_SDK_
 RUN git clone https://github.com/JuulLabs-OSS/mcuboot.git /opt/mcuboot && pip3 install -r /opt/mcuboot/scripts/requirements.txt
 RUN pip3 install adafruit-nrfutil
 
-USER user
+ARG PUID=1000
+ARG PGID=1000
+RUN groupadd --system --gid $PGID infinitime && useradd --system --uid $PUID --gid $PGID infinitime
+
+USER infinitime:infinitime
 CMD ["/sources/docker/build.sh"]


### PR DESCRIPTION
Docker files were:
* [x] Expanded for readability
* [x] More cleanup at each layer to reduce layer size
* [x] Re-ordered layers slightly to reduce rebuilds
* [x] Tweaked UID/GID for build/runtime overrides
* [x] Explicitly reference base image architecture
* [x] ~~Dockerfile folders were renamed to reflect base image architecture~~ Split to PR #139 to preserve history because git decided to be stupid
* [x] Re-add the updates to documentation

Testing after resync with current develop branch:
* [x] AMD64 - log in https://github.com/JF002/Pinetime/pull/137#issuecomment-745209758
* [x] ARM64v8 - log in https://github.com/JF002/Pinetime/pull/137#issuecomment-745209758

Docker Hub images have been pushed... the AMD64 image automatically builds on changes to my fork/PR branch at present, and the ARM64v8 image was built and pushed from my Pinebook Pro. 

~~`build/` was added to `.gitignore`~~ No longer needed as was done in PR #124

As before, this is nearly ready to go, just going to let it simmer for a week before I take the draft status off. 