### PR TITLE
add motor controller and vibration on notifications

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -374,6 +374,7 @@ list(APPEND SOURCE_FILES
         components/ble/ImmediateAlertService.cpp
         components/ble/ServiceDiscovery.cpp
         components/firmwarevalidator/FirmwareValidator.cpp
+        components/motor/MotorController.cpp
         drivers/Cst816s.cpp
         FreeRTOS/port.c
         FreeRTOS/port_cmsis_systick.c
@@ -454,6 +455,7 @@ set(INCLUDE_FILES
         components/ble/ImmediateAlertService.h
         components/ble/ServiceDiscovery.h
         components/ble/BleClient.h
+        components/motor/MotorController.h
         drivers/Cst816s.h
         FreeRTOS/portmacro.h
         FreeRTOS/portmacro_cmsis.h

--- a/src/components/motor/MotorController.cpp
+++ b/src/components/motor/MotorController.cpp
@@ -1,0 +1,16 @@
+#include "MotorController.h"
+#include <hal/nrf_gpio.h>
+#include "systemtask/SystemTask.h"
+
+using namespace Pinetime::Controllers;
+
+void MotorController::Init() {
+    nrf_gpio_cfg_output(pinMotor); // set the motor pin as an output
+    SetDuration(20);    //miliseconds
+}
+
+void MotorController::SetDuration(uint8_t motorDuration) {
+    nrf_gpio_pin_clear(pinMotor);
+    vTaskDelay(motorDuration);
+    nrf_gpio_pin_set(pinMotor);
+}

--- a/src/components/motor/MotorController.h
+++ b/src/components/motor/MotorController.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <cstdint>
+
+namespace Pinetime {
+  namespace Controllers {
+    class MotorController {
+    public:
+      void Init();
+      void SetDuration(uint8_t motorDuration);
+
+    private:
+      static constexpr uint8_t pinMotor = 16;
+    };
+  }
+}

--- a/src/displayapp/screens/Notifications.cpp
+++ b/src/displayapp/screens/Notifications.cpp
@@ -2,10 +2,11 @@
 #include <displayapp/DisplayApp.h>
 
 using namespace Pinetime::Applications::Screens;
-
 Notifications::Notifications(DisplayApp *app, Pinetime::Controllers::NotificationManager &notificationManager, Modes mode) :
         Screen(app), notificationManager{notificationManager}, mode{mode} {
   notificationManager.ClearNewNotificationFlag();
+  motorController.Init();
+
   auto notification = notificationManager.GetLastNotification();
   if(notification.valid) {
     currentId = notification.id;
@@ -22,6 +23,7 @@ Notifications::Notifications(DisplayApp *app, Pinetime::Controllers::Notificatio
     style_line.line.width = 3;
     style_line.line.rounded = 0;
 
+    motorController.SetDuration(35);
 
     timeoutLine = lv_line_create(lv_scr_act(), nullptr);
     lv_line_set_style(timeoutLine, LV_LINE_STYLE_MAIN, &style_line);

--- a/src/displayapp/screens/Notifications.h
+++ b/src/displayapp/screens/Notifications.h
@@ -5,6 +5,8 @@
 #include <memory>
 #include "Screen.h"
 #include "components/ble/NotificationManager.h"
+#include "components/motor/MotorController.h"
+
 
 namespace Pinetime {
   namespace Applications {
@@ -45,6 +47,7 @@ namespace Pinetime {
             const char* text;
           };
           Pinetime::Controllers::NotificationManager& notificationManager;
+          Pinetime::Controllers::MotorController motorController;
           Modes mode = Modes::Normal;
           std::unique_ptr<NotificationItem> currentItem;
           Controllers::NotificationManager::Notification::Id currentId;


### PR DESCRIPTION
Adding the motor controller from [ZephyrLabs](https://github.com/ZephyrLabs/Watchfaces/tree/gh-pages/docs/Terminal) to enable vibrations on notifications.

More info from ZephyrLabs: https://zephyrlabs.github.io/Watchfaces/Terminal/

Not sure why this has not been put in a PR yet and tried to get in contact with @ZephyrLabs through this issue to ask why. https://github.com/ZephyrLabs/Watchfaces/issues/3

This works on my Pinetime atleast, though it also vibrates when opening the notification tab from the menu aswell. Could easily be modified if needed.