### PR TITLE
Fix erratic battery

### DIFF
--- a/src/components/battery/BatteryController.cpp
+++ b/src/components/battery/BatteryController.cpp
@@ -34,9 +34,9 @@ void Battery::Update() {
 
   // see https://forum.pine64.org/showthread.php?tid=8147
   voltage = (value * 2.0f) / (1024/3.0f);
-  float percentRemaining = ((voltage - 3.55f)*100.0f)*3.9f;
-  percentRemaining = std::max(percentRemaining, 0.0f);
-  percentRemaining = std::min(percentRemaining, 100.0f);
+  int percentRemaining = ((voltage - 3.55f)*100.0f)*3.9f;
+  percentRemaining = std::max(percentRemaining, 0);
+  percentRemaining = std::min(percentRemaining, 100);
 
   percentRemainingBuffer.insert(percentRemaining);
 

--- a/src/components/battery/BatteryController.cpp
+++ b/src/components/battery/BatteryController.cpp
@@ -34,9 +34,11 @@ void Battery::Update() {
 
   // see https://forum.pine64.org/showthread.php?tid=8147
   voltage = (value * 2.0f) / (1024/3.0f);
-  percentRemaining = ((voltage - 3.55f)*100.0f)*3.9f;
+  float percentRemaining = ((voltage - 3.55f)*100.0f)*3.9f;
   percentRemaining = std::max(percentRemaining, 0.0f);
   percentRemaining = std::min(percentRemaining, 100.0f);
+
+  percentRemainingBuffer.insert(percentRemaining);
 
 //  NRF_LOG_INFO("BATTERY " NRF_LOG_FLOAT_MARKER " %% - " NRF_LOG_FLOAT_MARKER " v", NRF_LOG_FLOAT(percentRemaining), NRF_LOG_FLOAT(voltage));
 //  NRF_LOG_INFO("POWER Charging : %d - Power : %d", isCharging, isPowerPresent);

--- a/src/components/battery/BatteryController.h
+++ b/src/components/battery/BatteryController.h
@@ -6,15 +6,21 @@
 
 namespace Pinetime {
   namespace Controllers {
-  // A simple circular buffer that can be used to average 
-  // out the sensor values
+  /** A simple circular buffer that can be used to average 
+   out the sensor values. The total capacity of the CircBuffer  
+   is given as the template parameter N.
+   */ 
   template <int N> 
   class CircBuffer {
   public:
-    CircBuffer() : arr{}, sz{}, cap{N}, loc{} {}
+    CircBuffer() : arr{}, sz{}, cap{N}, head{} {}
+    /**
+   insert member function overwrites the next data to the current 
+   HEAD and moves the HEAD to the newly inserted value.
+   */ 
     void insert(const int num) {
-      loc %= cap;
-      arr[loc++] = num;
+      head %= cap;
+      arr[head++] = num;
       if (sz != cap) {
         sz++;
       }
@@ -26,10 +32,10 @@ namespace Pinetime {
     }
 
   private:
-    std::array<int, N> arr;
-    uint8_t sz;
-    uint8_t cap;
-    uint8_t loc;
+    std::array<int, N> arr; /**< internal array used to store the values*/
+    uint8_t sz; /**< The current size of the array.*/
+    uint8_t cap; /**< Total capacity of the CircBuffer.*/
+    uint8_t head; /**< The current head of the CircBuffer*/
   };
 
     class Battery {

--- a/src/components/battery/BatteryController.h
+++ b/src/components/battery/BatteryController.h
@@ -21,7 +21,7 @@ namespace Pinetime {
     }
 
     int GetAverage() const {
-      int sum = std::accumulate(arr.begin(), arr.end(), 0.0f);
+      int sum = std::accumulate(arr.begin(), arr.end(), 0);
       return (sum / sz);
     }
 

--- a/src/components/battery/BatteryController.h
+++ b/src/components/battery/BatteryController.h
@@ -21,7 +21,7 @@ namespace Pinetime {
     }
 
     float GetAverage() const {
-      float sum = std::accumulate(arr.begin(), arr.end(), 0);
+      float sum = std::accumulate(arr.begin(), arr.end(), 0.0f);
       return (sum / sz);
     }
 
@@ -31,6 +31,7 @@ namespace Pinetime {
     uint8_t cap;
     uint8_t loc;
   };
+
     class Battery {
       public:
         void Init();

--- a/src/components/battery/BatteryController.h
+++ b/src/components/battery/BatteryController.h
@@ -12,7 +12,7 @@ namespace Pinetime {
   class CircBuffer {
   public:
     CircBuffer() : arr{}, sz{}, cap{N}, loc{} {}
-    void insert(const float num) {
+    void insert(const int num) {
       loc %= cap;
       arr[loc++] = num;
       if (sz != cap) {
@@ -26,7 +26,7 @@ namespace Pinetime {
     }
 
   private:
-    std::array<float, N> arr;
+    std::array<int, N> arr;
     uint8_t sz;
     uint8_t cap;
     uint8_t loc;

--- a/src/components/battery/BatteryController.h
+++ b/src/components/battery/BatteryController.h
@@ -20,8 +20,8 @@ namespace Pinetime {
       }
     }
 
-    float GetAverage() const {
-      float sum = std::accumulate(arr.begin(), arr.end(), 0.0f);
+    int GetAverage() const {
+      int sum = std::accumulate(arr.begin(), arr.end(), 0.0f);
       return (sum / sz);
     }
 
@@ -36,7 +36,7 @@ namespace Pinetime {
       public:
         void Init();
         void Update();
-        float PercentRemaining() const { return percentRemainingBuffer.GetAverage(); }
+        int PercentRemaining() const { return percentRemainingBuffer.GetAverage(); }
         float Voltage() const { return voltage; }
         bool IsCharging() const { return isCharging; }
         bool IsPowerPresent() const { return isPowerPresent; }

--- a/src/components/battery/BatteryController.h
+++ b/src/components/battery/BatteryController.h
@@ -1,14 +1,41 @@
 #pragma once
 #include <cstdint>
 #include <drivers/include/nrfx_saadc.h>
+#include <array>
+#include <numeric>
 
 namespace Pinetime {
   namespace Controllers {
+  // A simple circular buffer that can be used to average 
+  // out sensor values
+  template <int N> 
+  class CircBuffer {
+  public:
+    CircBuffer() : arr{}, sz{}, cap{N}, loc{} {}
+    void insert(const float num) {
+      loc %= cap;
+      arr[loc++] = num;
+      if (sz != cap) {
+        sz++;
+      }
+    }
+
+    float GetAverage() const {
+      float sum = std::accumulate(arr.begin(), arr.end(), 0);
+      return (sum / sz);
+    }
+
+  private:
+    std::array<float, N> arr;
+    uint8_t sz;
+    uint8_t cap;
+    uint8_t loc;
+  };
     class Battery {
       public:
         void Init();
         void Update();
-        float PercentRemaining() const { return percentRemaining; }
+        float PercentRemaining() const { return percentRemainingBuffer.GetAverage(); }
         float Voltage() const { return voltage; }
         bool IsCharging() const { return isCharging; }
         bool IsPowerPresent() const { return isPowerPresent; }
@@ -17,8 +44,9 @@ namespace Pinetime {
         static constexpr uint32_t chargingPin = 12;
         static constexpr uint32_t powerPresentPin = 19;
         static constexpr nrf_saadc_input_t batteryVoltageAdcInput = NRF_SAADC_INPUT_AIN7;
+        static constexpr uint8_t percentRemainingSamples = 10;
         static void SaadcEventHandler(nrfx_saadc_evt_t const * p_event);
-        float percentRemaining = 0.0f;
+        CircBuffer<percentRemainingSamples> percentRemainingBuffer {};
         float voltage = 0.0f;
         bool isCharging = false;
         bool isPowerPresent = false;

--- a/src/components/battery/BatteryController.h
+++ b/src/components/battery/BatteryController.h
@@ -7,7 +7,7 @@
 namespace Pinetime {
   namespace Controllers {
   // A simple circular buffer that can be used to average 
-  // out sensor values
+  // out the sensor values
   template <int N> 
   class CircBuffer {
   public:

--- a/src/displayapp/screens/BatteryIcon.cpp
+++ b/src/displayapp/screens/BatteryIcon.cpp
@@ -3,11 +3,11 @@
 
 using namespace Pinetime::Applications::Screens;
 
-const char* BatteryIcon::GetBatteryIcon(float batteryPercent) {
-  if(batteryPercent > 90.0f) return Symbols::batteryFull;
-  if(batteryPercent > 75.0f) return Symbols::batteryThreeQuarter;
-  if(batteryPercent > 50.0f) return Symbols::batteryHalf;
-  if(batteryPercent > 25.0f) return Symbols::batteryOneQuarter;
+const char* BatteryIcon::GetBatteryIcon(int batteryPercent) {
+  if(batteryPercent > 90) return Symbols::batteryFull;
+  if(batteryPercent > 75) return Symbols::batteryThreeQuarter;
+  if(batteryPercent > 50) return Symbols::batteryHalf;
+  if(batteryPercent > 25) return Symbols::batteryOneQuarter;
   return Symbols::batteryEmpty;
 }
 

--- a/src/displayapp/screens/BatteryIcon.h
+++ b/src/displayapp/screens/BatteryIcon.h
@@ -6,7 +6,7 @@ namespace Pinetime {
       class BatteryIcon {
       public:
         static const char* GetUnknownIcon();
-          static const char* GetBatteryIcon(float batteryPercent);
+          static const char* GetBatteryIcon(int batteryPercent);
           static const char* GetPlugIcon(bool isCharging);
       };
     }

--- a/src/displayapp/screens/Clock.cpp
+++ b/src/displayapp/screens/Clock.cpp
@@ -98,7 +98,8 @@ bool Clock::Refresh() {
   batteryPercentRemaining = batteryController.PercentRemaining();
   if (batteryPercentRemaining.IsUpdated()) {
     auto batteryPercent = batteryPercentRemaining.Get();
-    lv_label_set_text(batteryIcon, BatteryIcon::GetBatteryIcon(batteryPercent));
+    // lv_label_set_text(batteryIcon, BatteryIcon::GetBatteryIcon(batteryPercent));
+    lv_label_set_text(batteryIcon, std::to_string(batteryPercent).c_str());
     auto isCharging = batteryController.IsCharging() || batteryController.IsPowerPresent();
     lv_label_set_text(batteryPlug, BatteryIcon::GetPlugIcon(isCharging));
   }

--- a/src/displayapp/screens/Clock.cpp
+++ b/src/displayapp/screens/Clock.cpp
@@ -98,8 +98,7 @@ bool Clock::Refresh() {
   batteryPercentRemaining = batteryController.PercentRemaining();
   if (batteryPercentRemaining.IsUpdated()) {
     auto batteryPercent = batteryPercentRemaining.Get();
-    // lv_label_set_text(batteryIcon, BatteryIcon::GetBatteryIcon(batteryPercent));
-    lv_label_set_text(batteryIcon, std::to_string(batteryPercent).c_str());
+    lv_label_set_text(batteryIcon, BatteryIcon::GetBatteryIcon(batteryPercent));
     auto isCharging = batteryController.IsCharging() || batteryController.IsPowerPresent();
     lv_label_set_text(batteryPlug, BatteryIcon::GetPlugIcon(isCharging));
   }

--- a/src/displayapp/screens/Clock.h
+++ b/src/displayapp/screens/Clock.h
@@ -62,7 +62,7 @@ namespace Pinetime {
           Pinetime::Controllers::DateTime::Days currentDayOfWeek = Pinetime::Controllers::DateTime::Days::Unknown;
           uint8_t currentDay = 0;
 
-          DirtyValue<float> batteryPercentRemaining  {0};
+          DirtyValue<int> batteryPercentRemaining  {0};
           DirtyValue<bool> bleState {false};
           DirtyValue<std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>> currentDateTime;
           DirtyValue<uint32_t> stepCount  {0};


### PR DESCRIPTION
This addresses #146 issue by averaging out the battery percent value. 
As a part of this PR, I have done the following changes: 
- Added a very simple circular buffer. I was thinking initially to use the `nrf_ringbuf`, but the API is very C-like and probably I don't need all the features that come with it. 
- Changed the percent value to be an `int` instead of a `float`. Floating-point arithmetic is generally more expensive and the user is not really interested in decimal level accuracy for battery percentage. I also noticed in many places where they are used, they are being downcasted to a smaller data type anyway. (e.g., see SystemInfo.cpp:50)

Tested it on the devkit. The battery variation reduced from +- 8% to +- 1%. 