### PR TITLE
Heart rate sensor

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -375,6 +375,7 @@ list(APPEND SOURCE_FILES
         components/ble/BatteryInformationService.cpp
         components/ble/ImmediateAlertService.cpp
         components/ble/ServiceDiscovery.cpp
+        components/ble/HeartRateService.cpp
         components/firmwarevalidator/FirmwareValidator.cpp
         drivers/Cst816s.cpp
         FreeRTOS/port.c
@@ -464,6 +465,7 @@ set(INCLUDE_FILES
         components/ble/ImmediateAlertService.h
         components/ble/ServiceDiscovery.h
         components/ble/BleClient.h
+        components/ble/HeartRateService.h.h
         drivers/Cst816s.h
         FreeRTOS/portmacro.h
         FreeRTOS/portmacro_cmsis.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -349,6 +349,7 @@ list(APPEND SOURCE_FILES
         displayapp/screens/ApplicationList.cpp
         displayapp/screens/Notifications.cpp
         displayapp/screens/Twos.cpp
+        displayapp/screens/HeartRate.cpp
         main.cpp
         drivers/St7789.cpp
         drivers/SpiNorFlash.cpp
@@ -357,6 +358,7 @@ list(APPEND SOURCE_FILES
         drivers/Watchdog.cpp
         drivers/DebugPins.cpp
         drivers/InternalFlash.cpp
+        drivers/Hrs3300.cpp
         components/battery/BatteryController.cpp
         components/ble/BleController.cpp
         components/ble/NotificationManager.cpp
@@ -385,6 +387,12 @@ list(APPEND SOURCE_FILES
 
         systemtask/SystemTask.cpp
         drivers/TwiMaster.cpp
+
+        heartratetask/HeartRateTask.cpp
+        components/heartrate/Ppg.cpp
+        components/heartrate/Biquad.cpp
+        components/heartrate/Ptagc.cpp
+        components/heartrate/HeartRateController.cpp
         )
 
 list(APPEND GRAPHICS_SOURCE_FILES
@@ -432,6 +440,7 @@ set(INCLUDE_FILES
         displayapp/screens/ApplicationList.h
         displayapp/Apps.h
         displayapp/screens/Notifications.h
+        displayapp/screens/HeartRate.h
         drivers/St7789.h
         drivers/SpiNorFlash.h
         drivers/SpiMaster.h
@@ -439,6 +448,7 @@ set(INCLUDE_FILES
         drivers/Watchdog.h
         drivers/DebugPins.h
         drivers/InternalFlash.h
+        drivers/Hrs3300.h
         components/battery/BatteryController.h
         components/ble/BleController.h
         components/ble/NotificationManager.h
@@ -470,6 +480,11 @@ set(INCLUDE_FILES
         systemtask/SystemMonitor.h
         displayapp/screens/Symbols.h
         drivers/TwiMaster.h
+        heartratetask/HeartRateTask.h
+        components/heartrate/Ppg.h
+        components/heartrate/Biquad.h
+        components/heartrate/Ptagc.h
+        components/heartrate/HeartRateController.h
         )
 
 include_directories(

--- a/src/FreeRTOSConfig.h
+++ b/src/FreeRTOSConfig.h
@@ -63,7 +63,7 @@
 #define configTICK_RATE_HZ                                                        1024
 #define configMAX_PRIORITIES                                                      ( 3 )
 #define configMINIMAL_STACK_SIZE                                                  ( 120 )
-#define configTOTAL_HEAP_SIZE                                                     ( 1024*11 )
+#define configTOTAL_HEAP_SIZE                                                     ( 1024*14 )
 #define configMAX_TASK_NAME_LEN                                                   ( 4 )
 #define configUSE_16_BIT_TICKS                                                    0
 #define configIDLE_SHOULD_YIELD                                                   1

--- a/src/components/ble/HeartRateService.cpp
+++ b/src/components/ble/HeartRateService.cpp
@@ -1,0 +1,82 @@
+#include "HeartRateService.h"
+#include "components/heartrate/HeartRateController.h"
+#include "systemtask/SystemTask.h"
+
+using namespace Pinetime::Controllers;
+
+constexpr ble_uuid16_t HeartRateService::heartRateServiceUuid;
+constexpr ble_uuid16_t HeartRateService::heartRateMeasurementUuid;
+
+namespace {
+  int HeartRateServiceServiceCallback(uint16_t conn_handle, uint16_t attr_handle, struct ble_gatt_access_ctxt *ctxt, void *arg) {
+    auto* heartRateService = static_cast<HeartRateService*>(arg);
+    return heartRateService->OnHeartRateRequested(conn_handle, attr_handle, ctxt);
+  }
+}
+
+// TODO Refactoring - remove dependency to SystemTask
+HeartRateService::HeartRateService(Pinetime::System::SystemTask &system, Controllers::HeartRateController& heartRateController) :
+        system{system},
+        heartRateController{heartRateController},
+        characteristicDefinition{
+                {
+                        .uuid = (ble_uuid_t *) &heartRateMeasurementUuid,
+                        .access_cb = HeartRateServiceServiceCallback,
+                        .arg = this,
+                        .flags = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_NOTIFY,
+                        .val_handle = &heartRateMeasurementHandle
+                },
+                {
+                        0
+                }
+        },
+        serviceDefinition{
+                {
+                        /* Device Information Service */
+                        .type = BLE_GATT_SVC_TYPE_PRIMARY,
+                        .uuid = (ble_uuid_t *) &heartRateServiceUuid,
+                        .characteristics = characteristicDefinition
+                },
+                {
+                        0
+                },
+        }{
+  // TODO refactor to prevent this loop dependency (service depends on controller and controller depends on service)
+  heartRateController.SetService(this);
+}
+
+void HeartRateService::Init() {
+  int res = 0;
+  res = ble_gatts_count_cfg(serviceDefinition);
+  ASSERT(res == 0);
+
+  res = ble_gatts_add_svcs(serviceDefinition);
+  ASSERT(res == 0);
+}
+
+int HeartRateService::OnHeartRateRequested(uint16_t connectionHandle, uint16_t attributeHandle,
+                                           ble_gatt_access_ctxt *context) {
+  if(attributeHandle == heartRateMeasurementHandle) {
+    NRF_LOG_INFO("BATTERY : handle = %d", heartRateMeasurementHandle);
+    static uint8_t batteryValue = heartRateController.HeartRate();
+
+    uint8_t buffer[2] = {0, heartRateController.HeartRate()}; // [0] = flags, [1] = hr value
+
+    int res = os_mbuf_append(context->om, buffer, 2);
+    return (res == 0) ? 0 : BLE_ATT_ERR_INSUFFICIENT_RES;
+  }
+  return 0;
+}
+
+void HeartRateService::OnNewHeartRateValue(uint8_t heartRateValue) {
+  uint8_t buffer[2] = {0, heartRateController.HeartRate()}; // [0] = flags, [1] = hr value
+  auto *om = ble_hs_mbuf_from_flat(buffer, 2);
+
+  uint16_t connectionHandle = system.nimble().connHandle();
+
+  if (connectionHandle == 0 || connectionHandle == BLE_HS_CONN_HANDLE_NONE) {
+    return;
+  }
+
+  ble_gattc_notify_custom(connectionHandle, heartRateMeasurementHandle, om);
+}

--- a/src/components/ble/HeartRateService.h
+++ b/src/components/ble/HeartRateService.h
@@ -1,0 +1,44 @@
+#pragma once
+#define min // workaround: nimble's min/max macros conflict with libstdc++
+#define max
+#include <host/ble_gap.h>
+#undef max
+#undef min
+
+namespace Pinetime {
+  namespace System {
+    class SystemTask;
+  }
+  namespace Controllers {
+    class HeartRateController;
+    class HeartRateService {
+      public:
+        HeartRateService(Pinetime::System::SystemTask &system, Controllers::HeartRateController& heartRateController);
+        void Init();
+        int OnHeartRateRequested(uint16_t connectionHandle, uint16_t attributeHandle, ble_gatt_access_ctxt *context);
+        void OnNewHeartRateValue(uint8_t hearRateValue);
+
+    private:
+        Pinetime::System::SystemTask &system;
+        Controllers::HeartRateController& heartRateController;
+        static constexpr uint16_t heartRateServiceId {0x180D};
+        static constexpr uint16_t heartRateMeasurementId {0x2A37};
+
+        static constexpr ble_uuid16_t heartRateServiceUuid {
+                .u {.type = BLE_UUID_TYPE_16},
+                .value = heartRateServiceId
+        };
+
+        static constexpr ble_uuid16_t heartRateMeasurementUuid {
+                .u {.type = BLE_UUID_TYPE_16},
+                .value = heartRateMeasurementId
+        };
+
+        struct ble_gatt_chr_def characteristicDefinition[3];
+        struct ble_gatt_svc_def serviceDefinition[2];
+
+        uint16_t heartRateMeasurementHandle;
+
+    };
+  }
+}

--- a/src/components/ble/NimbleController.cpp
+++ b/src/components/ble/NimbleController.cpp
@@ -22,7 +22,8 @@ NimbleController::NimbleController(Pinetime::System::SystemTask& systemTask,
         DateTime& dateTimeController,
         Pinetime::Controllers::NotificationManager& notificationManager,
         Controllers::Battery& batteryController,
-        Pinetime::Drivers::SpiNorFlash& spiNorFlash) :
+        Pinetime::Drivers::SpiNorFlash& spiNorFlash,
+        Controllers::HeartRateController& heartRateController) :
         systemTask{systemTask},
         bleController{bleController},
         dateTimeController{dateTimeController},
@@ -36,7 +37,8 @@ NimbleController::NimbleController(Pinetime::System::SystemTask& systemTask,
         musicService{systemTask},
         batteryInformationService{batteryController},
         immediateAlertService{systemTask, notificationManager},
-        serviceDiscovery({&currentTimeClient, &alertNotificationClient}) {
+        serviceDiscovery({&currentTimeClient, &alertNotificationClient}),
+        heartRateService{systemTask, heartRateController} {
 }
 
 int GAPEventCallback(struct ble_gap_event *event, void *arg) {
@@ -58,6 +60,7 @@ void NimbleController::Init() {
   dfuService.Init();
   batteryInformationService.Init();
   immediateAlertService.Init();
+  heartRateService.Init();
   int res;
   res = ble_hs_util_ensure_addr(0);
   ASSERT(res == 0);

--- a/src/components/ble/NimbleController.h
+++ b/src/components/ble/NimbleController.h
@@ -17,6 +17,7 @@
 #include "ImmediateAlertService.h"
 #include "MusicService.h"
 #include "ServiceDiscovery.h"
+#include "HeartRateService.h"
 
 namespace Pinetime {
   namespace Drivers {
@@ -37,7 +38,8 @@ namespace Pinetime {
       public:
         NimbleController(Pinetime::System::SystemTask& systemTask, Pinetime::Controllers::Ble& bleController,
                 DateTime& dateTimeController, Pinetime::Controllers::NotificationManager& notificationManager,
-                Controllers::Battery& batteryController, Pinetime::Drivers::SpiNorFlash& spiNorFlash);
+                Controllers::Battery& batteryController, Pinetime::Drivers::SpiNorFlash& spiNorFlash,
+                Controllers::HeartRateController& heartRateController);
         void Init();
         void StartAdvertising();
         int OnGAPEvent(ble_gap_event *event);
@@ -74,6 +76,7 @@ namespace Pinetime {
         MusicService musicService;
         BatteryInformationService batteryInformationService;
         ImmediateAlertService immediateAlertService;
+        HeartRateService heartRateService;
 
         uint8_t addrType; // 1 = Random, 0 = PUBLIC
         uint16_t connectionHandle = 0;

--- a/src/components/heartrate/Biquad.cpp
+++ b/src/components/heartrate/Biquad.cpp
@@ -1,7 +1,14 @@
+/*
+  SPDX-License-Identifier: LGPL-3.0-or-later
+  Original work Copyright (C) 2020 Daniel Thompson
+  C++ port Copyright (C) 2021 Jean-François Milants
+*/
+
 #include "Biquad.h"
 
 using namespace Pinetime::Controllers;
 
+/** Original implementation from wasp-os : https://github.com/daniel-thompson/wasp-os/blob/master/wasp/ppg.py */
 Biquad::Biquad(float b0, float b1, float b2, float a1, float a2) : b0{b0}, b1{b1}, b2{b2}, a1{a1}, a2{a2} {
 
 }

--- a/src/components/heartrate/Biquad.cpp
+++ b/src/components/heartrate/Biquad.cpp
@@ -1,0 +1,20 @@
+#include "Biquad.h"
+
+using namespace Pinetime::Controllers;
+
+Biquad::Biquad(float b0, float b1, float b2, float a1, float a2) : b0{b0}, b1{b1}, b2{b2}, a1{a1}, a2{a2} {
+
+}
+
+float Biquad::Step(float x) {
+  auto v1 = this->v1;
+  auto v2 = this->v2;
+
+  auto v = x - (a1 * v1) - (a2 * v2);
+  auto y = (b0 * v) + (b1 * v1) + (b2 * v2);
+
+  this->v2 = v1;
+  this->v1 = v;
+
+  return y;
+}

--- a/src/components/heartrate/Biquad.h
+++ b/src/components/heartrate/Biquad.h
@@ -1,0 +1,22 @@
+#pragma once
+
+namespace Pinetime {
+  namespace Controllers {
+    /// Direct Form II Biquad Filter
+    class Biquad {
+    public:
+      Biquad(float b0, float  b1, float b2, float a1, float a2);
+      float Step(float x);
+
+    private:
+      float b0;
+      float b1;
+      float b2;
+      float a1;
+      float a2;
+
+      float v1 = 0.0f;
+      float v2 = 0.0f;
+    };
+  }
+}

--- a/src/components/heartrate/HeartRateController.cpp
+++ b/src/components/heartrate/HeartRateController.cpp
@@ -11,7 +11,10 @@ HeartRateController::HeartRateController(Pinetime::System::SystemTask &systemTas
 
 void HeartRateController::Update(HeartRateController::States newState, uint8_t heartRate) {
   this->state = newState;
-  this->heartRate = heartRate;
+  if(this->heartRate != heartRate) {
+    this->heartRate = heartRate;
+    service->OnNewHeartRateValue(heartRate);
+  }
 }
 
 void HeartRateController::Start() {
@@ -30,5 +33,9 @@ void HeartRateController::Stop() {
 
 void HeartRateController::SetHeartRateTask(Pinetime::Applications::HeartRateTask *task) {
   this->task = task;
+}
+
+void HeartRateController::SetService(Pinetime::Controllers::HeartRateService *service) {
+  this->service = service;
 }
 

--- a/src/components/heartrate/HeartRateController.cpp
+++ b/src/components/heartrate/HeartRateController.cpp
@@ -1,0 +1,23 @@
+#include "HeartRateController.h"
+#include <heartratetask/HeartRateTask.h>
+
+using namespace Pinetime::Controllers;
+
+void HeartRateController::Update(HeartRateController::States newState, uint8_t heartRate) {
+  this->state = newState;
+  this->heartRate = heartRate;
+}
+
+void HeartRateController::Start() {
+  if(task != nullptr)
+    task->PushMessage(Pinetime::Applications::HeartRateTask::Messages::StartMeasurement);
+}
+
+void HeartRateController::Stop() {
+  if(task != nullptr)
+    task->PushMessage(Pinetime::Applications::HeartRateTask::Messages::StopMeasurement);
+}
+
+void HeartRateController::SetHeartRateTask(Pinetime::Applications::HeartRateTask *task) {
+  this->task = task;
+}

--- a/src/components/heartrate/HeartRateController.cpp
+++ b/src/components/heartrate/HeartRateController.cpp
@@ -1,7 +1,13 @@
 #include "HeartRateController.h"
 #include <heartratetask/HeartRateTask.h>
+#include <systemtask/SystemTask.h>
 
 using namespace Pinetime::Controllers;
+
+HeartRateController::HeartRateController(Pinetime::System::SystemTask &systemTask) : systemTask{systemTask} {
+
+}
+
 
 void HeartRateController::Update(HeartRateController::States newState, uint8_t heartRate) {
   this->state = newState;
@@ -9,15 +15,20 @@ void HeartRateController::Update(HeartRateController::States newState, uint8_t h
 }
 
 void HeartRateController::Start() {
-  if(task != nullptr)
+  if(task != nullptr) {
     task->PushMessage(Pinetime::Applications::HeartRateTask::Messages::StartMeasurement);
+    systemTask.PushMessage(System::SystemTask::Messages::HeartRateRunning);
+  }
 }
 
 void HeartRateController::Stop() {
-  if(task != nullptr)
+  if(task != nullptr) {
     task->PushMessage(Pinetime::Applications::HeartRateTask::Messages::StopMeasurement);
+    systemTask.PushMessage(System::SystemTask::Messages::HeartRateStopped);
+  }
 }
 
 void HeartRateController::SetHeartRateTask(Pinetime::Applications::HeartRateTask *task) {
   this->task = task;
 }
+

--- a/src/components/heartrate/HeartRateController.cpp
+++ b/src/components/heartrate/HeartRateController.cpp
@@ -16,15 +16,15 @@ void HeartRateController::Update(HeartRateController::States newState, uint8_t h
 
 void HeartRateController::Start() {
   if(task != nullptr) {
+    state = States::NotEnoughData;
     task->PushMessage(Pinetime::Applications::HeartRateTask::Messages::StartMeasurement);
-    systemTask.PushMessage(System::SystemTask::Messages::HeartRateRunning);
   }
 }
 
 void HeartRateController::Stop() {
   if(task != nullptr) {
+    state = States::Stopped;
     task->PushMessage(Pinetime::Applications::HeartRateTask::Messages::StopMeasurement);
-    systemTask.PushMessage(System::SystemTask::Messages::HeartRateStopped);
   }
 }
 

--- a/src/components/heartrate/HeartRateController.h
+++ b/src/components/heartrate/HeartRateController.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <cstdint>
+
+namespace Pinetime {
+  namespace Applications {
+    class HeartRateTask;
+  }
+  namespace Controllers {
+    class HeartRateController {
+    public:
+      enum class States { NotEnoughData, NoTouch, Running};
+
+      void Start();
+      void Stop();
+      void Update(States newState, uint8_t heartRate);
+
+      void SetHeartRateTask(Applications::HeartRateTask* task);
+      States State() const { return state; }
+      uint8_t HeartRate() const { return heartRate; }
+
+    private:
+      Applications::HeartRateTask* task = nullptr;
+      States state = States::NotEnoughData;
+      uint8_t heartRate = 0;
+    };
+  }
+}

--- a/src/components/heartrate/HeartRateController.h
+++ b/src/components/heartrate/HeartRateController.h
@@ -12,7 +12,7 @@ namespace Pinetime {
   namespace Controllers {
     class HeartRateController {
     public:
-      enum class States { NotEnoughData, NoTouch, Running};
+      enum class States { Stopped, NotEnoughData, NoTouch, Running};
 
       explicit HeartRateController(System::SystemTask& systemTask);
 
@@ -27,7 +27,7 @@ namespace Pinetime {
     private:
       System::SystemTask& systemTask;
       Applications::HeartRateTask* task = nullptr;
-      States state = States::NotEnoughData;
+      States state = States::Stopped;
       uint8_t heartRate = 0;
     };
   }

--- a/src/components/heartrate/HeartRateController.h
+++ b/src/components/heartrate/HeartRateController.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <components/ble/HeartRateService.h>
 
 namespace Pinetime {
   namespace Applications {
@@ -24,11 +25,14 @@ namespace Pinetime {
       States State() const { return state; }
       uint8_t HeartRate() const { return heartRate; }
 
+      void SetService(Pinetime::Controllers::HeartRateService *service);
+
     private:
       System::SystemTask& systemTask;
       Applications::HeartRateTask* task = nullptr;
       States state = States::Stopped;
       uint8_t heartRate = 0;
+      Pinetime::Controllers::HeartRateService* service = nullptr;
     };
   }
 }

--- a/src/components/heartrate/HeartRateController.h
+++ b/src/components/heartrate/HeartRateController.h
@@ -6,10 +6,15 @@ namespace Pinetime {
   namespace Applications {
     class HeartRateTask;
   }
+  namespace System {
+    class SystemTask;
+  }
   namespace Controllers {
     class HeartRateController {
     public:
       enum class States { NotEnoughData, NoTouch, Running};
+
+      explicit HeartRateController(System::SystemTask& systemTask);
 
       void Start();
       void Stop();
@@ -20,6 +25,7 @@ namespace Pinetime {
       uint8_t HeartRate() const { return heartRate; }
 
     private:
+      System::SystemTask& systemTask;
       Applications::HeartRateTask* task = nullptr;
       States state = States::NotEnoughData;
       uint8_t heartRate = 0;

--- a/src/components/heartrate/Ppg.cpp
+++ b/src/components/heartrate/Ppg.cpp
@@ -1,0 +1,96 @@
+#include <vector>
+#include <nrf_log.h>
+#include "Ppg.h"
+using namespace Pinetime::Controllers;
+
+namespace {
+  // TODO no vector!
+  int Compare(int* d1, int* d2, size_t count) {
+    int e = 0;
+    for(int i = 0; i < count; i++) {
+      auto d = d1[i] - d2[i];
+      e += d * d;
+    }
+    return e;
+  }
+
+  int CompareShift(int* d, int shift, size_t count) {
+    return Compare(d +shift, d, count - shift);
+  }
+
+  int Trough(int* d, size_t size, float mn, float mx) {
+    auto z2 = CompareShift(d, mn-2, size);
+    auto z1 = CompareShift(d, mn-1, size);
+    for(int i = mn; i < mx + 1; i++) {
+      auto z = CompareShift(d, i, size);
+      if(z2 > z1 && z1 < z)
+        return i;
+      z2 = z1;
+      z1 = z;
+    }
+    return -1;
+  }
+}
+
+Ppg::Ppg(float spl) : offset{spl},
+                      hpf{0.87033078, -1.74066156, 0.87033078,-1.72377617, 0.75754694},
+                      agc{20, 0.971, 2},
+                      lpf{0.11595249, 0.23190498, 0.11595249,-0.72168143, 0.18549138} {
+
+}
+
+int Ppg::Preprocess(float spl) {
+  spl -= offset;
+  spl = hpf.Step(spl);
+  spl = agc.Step(spl);
+  spl = lpf.Step(spl);
+
+  auto spl_int = static_cast<int>(spl);
+
+  if(dataIndex < 200)
+    data[dataIndex++] = spl_int;
+  return spl_int;
+}
+
+float Ppg::HeartRate() {
+  if(dataIndex < 200)
+    return 0;
+
+  NRF_LOG_INFO("PREPROCESS, offset = %d", offset);
+  auto hr = ProcessHeartRate();
+  dataIndex = 0;
+  return hr;
+}
+
+int cccount = 0;
+float Ppg::ProcessHeartRate() {
+
+  if(cccount > 2)
+    asm("nop");
+  cccount ++;
+  auto t0 = Trough(data.data(), dataIndex, 7, 48);
+  if(t0 < 0)
+    return 0;
+
+  float t1 = t0 * 2;
+  t1 = Trough(data.data(), dataIndex, t1-5, t1+5);
+  if(t1 < 0)
+    return 0;
+
+  float t2 = static_cast<int>(t1 * 3) / 2;
+  t2 = Trough(data.data(), dataIndex, t2 - 5, t2 + 5);
+  if(t2 < 0)
+    return 0;
+
+  float t3 = static_cast<int>(t2 * 4) / 3;
+  t3 = Trough(data.data(), dataIndex, t3 - 4, t3 + 4);
+  if(t3 < 0)
+    return static_cast<int>(60 * 24 * 3) / static_cast<int>(t2);
+
+  return static_cast<int>(60 * 24 * 4) / static_cast<int>(t3);
+}
+
+void Ppg::SetOffset(uint16_t offset) {
+  this->offset = offset;
+  dataIndex = 0;
+}

--- a/src/components/heartrate/Ppg.cpp
+++ b/src/components/heartrate/Ppg.cpp
@@ -94,3 +94,7 @@ void Ppg::SetOffset(uint16_t offset) {
   this->offset = offset;
   dataIndex = 0;
 }
+
+void Ppg::Reset() {
+  dataIndex = 0;
+}

--- a/src/components/heartrate/Ppg.cpp
+++ b/src/components/heartrate/Ppg.cpp
@@ -1,10 +1,16 @@
+/*
+  SPDX-License-Identifier: LGPL-3.0-or-later
+  Original work Copyright (C) 2020 Daniel Thompson
+  C++ port Copyright (C) 2021 Jean-François Milants
+*/
+
 #include <vector>
 #include <nrf_log.h>
 #include "Ppg.h"
 using namespace Pinetime::Controllers;
 
+/** Original implementation from wasp-os : https://github.com/daniel-thompson/wasp-os/blob/master/wasp/ppg.py */
 namespace {
-  // TODO no vector!
   int Compare(int* d1, int* d2, size_t count) {
     int e = 0;
     for(int i = 0; i < count; i++) {

--- a/src/components/heartrate/Ppg.h
+++ b/src/components/heartrate/Ppg.h
@@ -14,6 +14,7 @@ namespace Pinetime {
       float HeartRate();
 
       void SetOffset(uint16_t i);
+      void Reset();
 
     private:
       std::array<int, 200> data;

--- a/src/components/heartrate/Ppg.h
+++ b/src/components/heartrate/Ppg.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <array>
+#include "Biquad.h"
+#include "Ptagc.h"
+
+namespace Pinetime {
+  namespace Controllers {
+    class Ppg {
+    public:
+      explicit Ppg(float spl);
+
+      int Preprocess(float spl);
+      float HeartRate();
+
+      void SetOffset(uint16_t i);
+
+    private:
+      std::array<int, 200> data;
+      size_t dataIndex = 0;
+      float offset;
+      Biquad hpf;
+      Ptagc agc;
+      Biquad lpf;
+
+
+      float ProcessHeartRate();
+    };
+  }
+}

--- a/src/components/heartrate/Ptagc.cpp
+++ b/src/components/heartrate/Ptagc.cpp
@@ -1,0 +1,21 @@
+#include <cmath>
+#include "Ptagc.h"
+
+using namespace Pinetime::Controllers;
+
+Ptagc::Ptagc(float start, float decay, float threshold) : peak{start}, decay{decay}, boost{1.0f/decay}, threshold{threshold} {
+
+}
+
+float Ptagc::Step(float spl) {
+  if(std::abs(spl) > peak)
+    peak *= boost;
+  else
+    peak *= decay;
+
+  if((spl > (peak * threshold)) || (spl < (peak * -threshold)))
+    return 0.0f;
+
+  spl = 100.0f * spl / (2.0f * peak);
+  return spl;
+}

--- a/src/components/heartrate/Ptagc.cpp
+++ b/src/components/heartrate/Ptagc.cpp
@@ -1,8 +1,15 @@
+/*
+  SPDX-License-Identifier: LGPL-3.0-or-later
+  Original work Copyright (C) 2020 Daniel Thompson
+  C++ port Copyright (C) 2021 Jean-François Milants
+*/
+
 #include <cmath>
 #include "Ptagc.h"
 
 using namespace Pinetime::Controllers;
 
+/** Original implementation from wasp-os : https://github.com/daniel-thompson/wasp-os/blob/master/wasp/ppg.py */
 Ptagc::Ptagc(float start, float decay, float threshold) : peak{start}, decay{decay}, boost{1.0f/decay}, threshold{threshold} {
 
 }

--- a/src/components/heartrate/Ptagc.h
+++ b/src/components/heartrate/Ptagc.h
@@ -1,0 +1,18 @@
+#pragma once
+
+namespace Pinetime {
+  namespace Controllers {
+    class Ptagc {
+    public:
+      Ptagc(float start, float decay, float threshold);
+      float Step(float spl);
+
+    private:
+      float peak;
+      float decay;
+      float boost;
+      float threshold;
+
+    };
+  }
+}

--- a/src/displayapp/Apps.h
+++ b/src/displayapp/Apps.h
@@ -2,6 +2,6 @@
 
 namespace Pinetime {
   namespace Applications {
-    enum class Apps {None, Launcher, Clock, SysInfo, Meter, Gauge, Brightness, Music, FirmwareValidation, Paint, Paddle, Notifications, Twos};
+    enum class Apps {None, Launcher, Clock, SysInfo, Meter, Gauge, Brightness, Music, FirmwareValidation, Paint, Paddle, Notifications, Twos, HeartRate};
   }
 }

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -1,5 +1,6 @@
 #include "DisplayApp.h"
 #include <libraries/log/nrf_log.h>
+#include <displayapp/screens/HeartRate.h>
 #include "components/battery/BatteryController.h"
 #include "components/ble/BleController.h"
 #include "components/datetime/DateTimeController.h"
@@ -29,7 +30,8 @@ DisplayApp::DisplayApp(Drivers::St7789 &lcd, Components::LittleVgl &lvgl, Driver
                        Controllers::Battery &batteryController, Controllers::Ble &bleController,
                        Controllers::DateTime &dateTimeController, Drivers::WatchdogView &watchdog,
                        System::SystemTask &systemTask,
-                       Pinetime::Controllers::NotificationManager& notificationManager) :
+                       Pinetime::Controllers::NotificationManager& notificationManager,
+                       Pinetime::Controllers::HeartRateController& heartRateController) :
         lcd{lcd},
         lvgl{lvgl},
         batteryController{batteryController},
@@ -39,7 +41,8 @@ DisplayApp::DisplayApp(Drivers::St7789 &lcd, Components::LittleVgl &lvgl, Driver
         touchPanel{touchPanel},
         currentScreen{new Screens::Clock(this, dateTimeController, batteryController, bleController, notificationManager) },
         systemTask{systemTask},
-        notificationManager{notificationManager} {
+        notificationManager{notificationManager},
+        heartRateController{heartRateController} {
   msgQueue = xQueueCreate(queueSize, itemSize);
   onClockApp = true;
   modal.reset(new Screens::Modal(this));
@@ -211,6 +214,7 @@ void DisplayApp::RunningState() {
       case Apps::Music : currentScreen.reset(new Screens::Music(this, systemTask.nimble().music())); break;
       case Apps::FirmwareValidation: currentScreen.reset(new Screens::FirmwareValidation(this, validator)); break;
       case Apps::Notifications: currentScreen.reset(new Screens::Notifications(this, notificationManager, Screens::Notifications::Modes::Normal)); break;
+      case Apps::HeartRate: currentScreen.reset(new Screens::HeartRate(this, heartRateController)); break;
     }
     nextApp = Apps::None;
   }

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -39,7 +39,7 @@ DisplayApp::DisplayApp(Drivers::St7789 &lcd, Components::LittleVgl &lvgl, Driver
         dateTimeController{dateTimeController},
         watchdog{watchdog},
         touchPanel{touchPanel},
-        currentScreen{new Screens::Clock(this, dateTimeController, batteryController, bleController, notificationManager) },
+        currentScreen{new Screens::Clock(this, dateTimeController, batteryController, bleController, notificationManager, heartRateController) },
         systemTask{systemTask},
         notificationManager{notificationManager},
         heartRateController{heartRateController} {
@@ -200,7 +200,7 @@ void DisplayApp::RunningState() {
       case Apps::None:
       case Apps::Launcher: currentScreen.reset(new Screens::ApplicationList(this)); break;
       case Apps::Clock:
-        currentScreen.reset(new Screens::Clock(this, dateTimeController, batteryController, bleController, notificationManager));
+        currentScreen.reset(new Screens::Clock(this, dateTimeController, batteryController, bleController, notificationManager, heartRateController));
         onClockApp = true;
         break;
 //      case Apps::Test: currentScreen.reset(new Screens::Message(this)); break;

--- a/src/displayapp/DisplayApp.h
+++ b/src/displayapp/DisplayApp.h
@@ -23,6 +23,7 @@ namespace Pinetime {
     class Ble;
     class DateTime;
     class NotificationManager;
+    class HeartRateController;
   }
 
   namespace System {
@@ -42,7 +43,8 @@ namespace Pinetime {
                    Controllers::Battery &batteryController, Controllers::Ble &bleController,
                    Controllers::DateTime &dateTimeController, Drivers::WatchdogView &watchdog,
                    System::SystemTask &systemTask,
-                   Pinetime::Controllers::NotificationManager& notificationManager);
+                   Pinetime::Controllers::NotificationManager& notificationManager,
+                   Pinetime::Controllers::HeartRateController& heartRateController);
         void Start();
         void PushMessage(Messages msg);
 
@@ -87,6 +89,7 @@ namespace Pinetime {
         Pinetime::Controllers::NotificationManager& notificationManager;
         Pinetime::Controllers::FirmwareValidator validator;
         TouchModes touchMode = TouchModes::Gestures;
+        Pinetime::Controllers::HeartRateController& heartRateController;
     };
   }
 }

--- a/src/displayapp/screens/ApplicationList.cpp
+++ b/src/displayapp/screens/ApplicationList.cpp
@@ -45,7 +45,7 @@ std::unique_ptr<Screen> ApplicationList::CreateScreen1() {
           {Symbols::sun, Apps::Brightness},
           {Symbols::list, Apps::SysInfo},
           {Symbols::check, Apps::FirmwareValidation},
-          {Symbols::none, Apps::None}
+          {Symbols::heartBeat, Apps::HeartRate}
           }
 
 

--- a/src/displayapp/screens/Clock.cpp
+++ b/src/displayapp/screens/Clock.cpp
@@ -10,6 +10,7 @@
 #include "components/battery/BatteryController.h"
 #include "components/ble/BleController.h"
 #include "components/ble/NotificationManager.h"
+#include "components/heartrate/HeartRateController.h"
 #include "../DisplayApp.h"
 
 using namespace Pinetime::Applications::Screens;
@@ -26,9 +27,11 @@ Clock::Clock(DisplayApp* app,
         Controllers::DateTime& dateTimeController,
         Controllers::Battery& batteryController,
         Controllers::Ble& bleController,
-        Controllers::NotificationManager& notificatioManager) : Screen(app), currentDateTime{{}},
+        Controllers::NotificationManager& notificatioManager,
+        Controllers::HeartRateController& heartRateController): Screen(app), currentDateTime{{}},
                                            dateTimeController{dateTimeController}, batteryController{batteryController},
-                                           bleController{bleController}, notificatioManager{notificatioManager} {
+                                           bleController{bleController}, notificatioManager{notificatioManager},
+                                           heartRateController{heartRateController} {
   displayedChar[0] = 0;
   displayedChar[1] = 0;
   displayedChar[2] = 0;
@@ -171,10 +174,15 @@ bool Clock::Refresh() {
     }
   }
 
-  // TODO heartbeat = heartBeatController.GetValue();
-  if(heartbeat.IsUpdated()) {
+  heartbeat = heartRateController.HeartRate();
+  heartbeatRunning = heartRateController.State() != Controllers::HeartRateController::States::Stopped;
+  if(heartbeat.IsUpdated() || heartbeatRunning.IsUpdated()) {
     char heartbeatBuffer[4];
-    sprintf(heartbeatBuffer, "%d", heartbeat.Get());
+    if(heartbeatRunning.Get())
+      sprintf(heartbeatBuffer, "%d", heartbeat.Get());
+    else
+      sprintf(heartbeatBuffer, "---");
+
     lv_label_set_text(heartbeatValue, heartbeatBuffer);
     lv_obj_align(heartbeatIcon, lv_scr_act(), LV_ALIGN_IN_BOTTOM_LEFT, 5, -2);
     lv_obj_align(heartbeatValue, heartbeatIcon, LV_ALIGN_OUT_RIGHT_MID, 5, 0);

--- a/src/displayapp/screens/Clock.h
+++ b/src/displayapp/screens/Clock.h
@@ -12,6 +12,7 @@ namespace Pinetime {
     class Battery;
     class Ble;
     class NotificationManager;
+    class HeartRateController;
   }
 
   namespace Applications {
@@ -42,7 +43,8 @@ namespace Pinetime {
                   Controllers::DateTime& dateTimeController,
                   Controllers::Battery& batteryController,
                   Controllers::Ble& bleController,
-                  Controllers::NotificationManager& notificatioManager);
+                  Controllers::NotificationManager& notificatioManager,
+                  Controllers::HeartRateController& heartRateController);
           ~Clock() override;
 
           bool Refresh() override;
@@ -67,6 +69,7 @@ namespace Pinetime {
           DirtyValue<std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>> currentDateTime;
           DirtyValue<uint32_t> stepCount  {0};
           DirtyValue<uint8_t> heartbeat  {0};
+          DirtyValue<bool> heartbeatRunning  {false};
           DirtyValue<bool> notificationState {false};
 
           lv_obj_t* label_time;
@@ -86,6 +89,7 @@ namespace Pinetime {
           Controllers::Battery& batteryController;
           Controllers::Ble& bleController;
           Controllers::NotificationManager& notificatioManager;
+          Controllers::HeartRateController& heartRateController;
 
           bool running = true;
 

--- a/src/displayapp/screens/HeartRate.cpp
+++ b/src/displayapp/screens/HeartRate.cpp
@@ -8,13 +8,25 @@ using namespace Pinetime::Applications::Screens;
 extern lv_font_t jetbrains_mono_extrabold_compressed;
 extern lv_font_t jetbrains_mono_bold_20;
 
-const char* ToString(Pinetime::Controllers::HeartRateController::States s) {
-  switch(s) {
-    case Pinetime::Controllers::HeartRateController::States::NotEnoughData: return "Not enough data,\nplease wait...";
-    case Pinetime::Controllers::HeartRateController::States::NoTouch: return "No touch detected";
-    case Pinetime::Controllers::HeartRateController::States::Running: return "Measuring...";
+namespace {
+  const char *ToString(Pinetime::Controllers::HeartRateController::States s) {
+    switch (s) {
+      case Pinetime::Controllers::HeartRateController::States::NotEnoughData:
+        return "Not enough data,\nplease wait...";
+      case Pinetime::Controllers::HeartRateController::States::NoTouch:
+        return "No touch detected";
+      case Pinetime::Controllers::HeartRateController::States::Running:
+        return "Measuring...";
+      case Pinetime::Controllers::HeartRateController::States::Stopped:
+        return "Stopped";
+    }
+    return "";
   }
-  return "";
+
+  static void btnStartStopEventHandler(lv_obj_t *obj, lv_event_t event) {
+    HeartRate *screen = static_cast<HeartRate *>(obj->user_data);
+    screen->OnStartStopEvent(event);
+  }
 }
 
 HeartRate::HeartRate(Pinetime::Applications::DisplayApp *app, Controllers::HeartRateController& heartRateController) : Screen(app), heartRateController{heartRateController} {
@@ -30,7 +42,7 @@ HeartRate::HeartRate(Pinetime::Applications::DisplayApp *app, Controllers::Heart
 
   label_hr = lv_label_create(lv_scr_act(), NULL);
   lv_label_set_style(label_hr, LV_LABEL_STYLE_MAIN, &labelBigStyle);
-  lv_obj_align(label_hr, lv_scr_act(), LV_ALIGN_CENTER, -70, 0);
+  lv_obj_align(label_hr, lv_scr_act(), LV_ALIGN_CENTER, -70, -40);
   lv_label_set_text(label_hr, "000");
 
   lv_label_set_text(label_bpm, "Heart rate BPM");
@@ -40,13 +52,19 @@ HeartRate::HeartRate(Pinetime::Applications::DisplayApp *app, Controllers::Heart
   label_status = lv_label_create(lv_scr_act(), NULL);
   lv_label_set_text(label_status, ToString(Pinetime::Controllers::HeartRateController::States::NotEnoughData));
   lv_label_set_style(label_status, LV_LABEL_STYLE_MAIN, labelStyle);
-  lv_obj_align(label_status, label_hr, LV_ALIGN_OUT_BOTTOM_MID, 0, 20);
+  lv_obj_align(label_status, label_hr, LV_ALIGN_OUT_BOTTOM_MID, 0, 10);
 
-  heartRateController.Start();
+  btn_startStop = lv_btn_create(lv_scr_act(), NULL);
+  btn_startStop->user_data = this;
+  lv_obj_set_height(btn_startStop, 50);
+  lv_obj_set_event_cb(btn_startStop, btnStartStopEventHandler);
+  lv_obj_align(btn_startStop, nullptr, LV_ALIGN_IN_BOTTOM_MID, 0, 0);
+
+  label_startStop = lv_label_create(btn_startStop, nullptr);
+  UpdateStartStopButton(heartRateController.State() != Controllers::HeartRateController::States::Stopped);
 }
 
 HeartRate::~HeartRate() {
-  heartRateController.Stop();
   lv_obj_clean(lv_scr_act());
 }
 
@@ -57,6 +75,7 @@ bool HeartRate::Refresh() {
   switch(state) {
     case Controllers::HeartRateController::States::NoTouch:
     case Controllers::HeartRateController::States::NotEnoughData:
+    case Controllers::HeartRateController::States::Stopped:
       lv_label_set_text(label_hr, "000");
       break;
     default:
@@ -65,7 +84,7 @@ bool HeartRate::Refresh() {
   }
 
   lv_label_set_text(label_status, ToString(state));
-  lv_obj_align(label_status, label_hr, LV_ALIGN_OUT_BOTTOM_MID, 0, 20);
+  lv_obj_align(label_status, label_hr, LV_ALIGN_OUT_BOTTOM_MID, 0, 10);
 
   return running;
 }
@@ -73,4 +92,24 @@ bool HeartRate::Refresh() {
 bool HeartRate::OnButtonPushed() {
   running = false;
   return true;
+}
+
+void HeartRate::OnStartStopEvent(lv_event_t event) {
+  if (event == LV_EVENT_CLICKED) {
+    if(heartRateController.State() == Controllers::HeartRateController::States::Stopped) {
+      heartRateController.Start();
+      UpdateStartStopButton(heartRateController.State() != Controllers::HeartRateController::States::Stopped);
+    }
+    else {
+      heartRateController.Stop();
+      UpdateStartStopButton(heartRateController.State() != Controllers::HeartRateController::States::Stopped);
+    }
+  }
+}
+
+void HeartRate::UpdateStartStopButton(bool isRunning) {
+  if(isRunning)
+    lv_label_set_text(label_startStop, "Stop");
+  else
+    lv_label_set_text(label_startStop, "Start");
 }

--- a/src/displayapp/screens/HeartRate.cpp
+++ b/src/displayapp/screens/HeartRate.cpp
@@ -1,0 +1,76 @@
+#include <libs/lvgl/lvgl.h>
+#include "HeartRate.h"
+#include <components/heartrate/HeartRateController.h>
+
+#include "../DisplayApp.h"
+
+using namespace Pinetime::Applications::Screens;
+extern lv_font_t jetbrains_mono_extrabold_compressed;
+extern lv_font_t jetbrains_mono_bold_20;
+
+const char* ToString(Pinetime::Controllers::HeartRateController::States s) {
+  switch(s) {
+    case Pinetime::Controllers::HeartRateController::States::NotEnoughData: return "Not enough data,\nplease wait...";
+    case Pinetime::Controllers::HeartRateController::States::NoTouch: return "No touch detected";
+    case Pinetime::Controllers::HeartRateController::States::Running: return "Measuring...";
+  }
+  return "";
+}
+
+HeartRate::HeartRate(Pinetime::Applications::DisplayApp *app, Controllers::HeartRateController& heartRateController) : Screen(app), heartRateController{heartRateController} {
+  label_bpm = lv_label_create(lv_scr_act(), NULL);
+
+  labelStyle = const_cast<lv_style_t *>(lv_label_get_style(label_bpm, LV_LABEL_STYLE_MAIN));
+  labelStyle->text.font = &jetbrains_mono_bold_20;
+
+  lv_style_copy(&labelBigStyle, labelStyle);
+  labelBigStyle.text.font = &jetbrains_mono_extrabold_compressed;
+
+  lv_label_set_style(label_bpm, LV_LABEL_STYLE_MAIN, labelStyle);
+
+  label_hr = lv_label_create(lv_scr_act(), NULL);
+  lv_label_set_style(label_hr, LV_LABEL_STYLE_MAIN, &labelBigStyle);
+  lv_obj_align(label_hr, lv_scr_act(), LV_ALIGN_CENTER, -70, 0);
+  lv_label_set_text(label_hr, "000");
+
+  lv_label_set_text(label_bpm, "Heart rate BPM");
+  lv_obj_align(label_bpm, label_hr, LV_ALIGN_OUT_TOP_MID, 0, -20);
+
+
+  label_status = lv_label_create(lv_scr_act(), NULL);
+  lv_label_set_text(label_status, ToString(Pinetime::Controllers::HeartRateController::States::NotEnoughData));
+  lv_label_set_style(label_status, LV_LABEL_STYLE_MAIN, labelStyle);
+  lv_obj_align(label_status, label_hr, LV_ALIGN_OUT_BOTTOM_MID, 0, 20);
+
+  heartRateController.Start();
+}
+
+HeartRate::~HeartRate() {
+  heartRateController.Stop();
+  lv_obj_clean(lv_scr_act());
+}
+
+bool HeartRate::Refresh() {
+  char hr[4];
+
+  auto state = heartRateController.State();
+  switch(state) {
+    case Controllers::HeartRateController::States::NoTouch:
+    case Controllers::HeartRateController::States::NotEnoughData:
+      lv_label_set_text(label_hr, "000");
+      break;
+    default:
+      sprintf(hr, "%03d", heartRateController.HeartRate());
+      lv_label_set_text(label_hr, hr);
+  }
+
+  lv_label_set_text(label_status, ToString(state));
+  lv_obj_align(label_status, label_hr, LV_ALIGN_OUT_BOTTOM_MID, 0, 20);
+
+  return running;
+}
+
+bool HeartRate::OnButtonPushed() {
+  running = false;
+  return true;
+}

--- a/src/displayapp/screens/HeartRate.h
+++ b/src/displayapp/screens/HeartRate.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <cstdint>
+#include <chrono>
+#include "Screen.h"
+#include <bits/unique_ptr.h>
+#include <libs/lvgl/src/lv_core/lv_style.h>
+#include <libs/lvgl/src/lv_core/lv_obj.h>
+
+namespace Pinetime {
+  namespace Controllers {
+    class HeartRateController;
+  }
+  namespace Applications {
+    namespace Screens {
+
+      class HeartRate : public Screen{
+      public:
+        HeartRate(DisplayApp* app, Controllers::HeartRateController& HeartRateController);
+        ~HeartRate() override;
+
+        bool Refresh() override;
+        bool OnButtonPushed() override;
+
+      private:
+        Controllers::HeartRateController& heartRateController;
+        lv_obj_t* label_hr;
+        lv_obj_t* label_bpm;
+        lv_obj_t* label_status;
+        lv_style_t labelBigStyle;
+        lv_style_t* labelStyle;
+
+        bool running = true;
+
+      };
+    }
+  }
+}

--- a/src/displayapp/screens/HeartRate.h
+++ b/src/displayapp/screens/HeartRate.h
@@ -21,14 +21,18 @@ namespace Pinetime {
 
         bool Refresh() override;
         bool OnButtonPushed() override;
+        void OnStartStopEvent(lv_event_t event);
 
       private:
         Controllers::HeartRateController& heartRateController;
+        void UpdateStartStopButton(bool isRunning);
         lv_obj_t* label_hr;
         lv_obj_t* label_bpm;
         lv_obj_t* label_status;
         lv_style_t labelBigStyle;
         lv_style_t* labelStyle;
+        lv_obj_t* btn_startStop;
+        lv_obj_t* label_startStop;
 
         bool running = true;
 

--- a/src/drivers/Hrs3300.cpp
+++ b/src/drivers/Hrs3300.cpp
@@ -1,0 +1,108 @@
+#include <algorithm>
+#include <nrf_gpio.h>
+#include "Hrs3300.h"
+
+#include <FreeRTOS.h>
+#include <task.h>
+#include <nrf_log.h>
+
+using namespace Pinetime::Drivers;
+
+Hrs3300::Hrs3300(TwiMaster &twiMaster, uint8_t twiAddress) : twiMaster{twiMaster}, twiAddress{twiAddress} {
+
+}
+
+void Hrs3300::Init() {
+  nrf_gpio_cfg_input(30, NRF_GPIO_PIN_NOPULL);
+
+  Disable();
+  vTaskDelay(100);
+
+  // HRS disabled, 12.5 ms wait time between cycles, (partly) 20mA drive
+  WriteRegister(static_cast<uint8_t>(Registers::Enable), 0x60);
+
+  // (partly) 20mA drive, power on, "magic" (datasheet says both
+  // "reserved" and "set low nibble to 8" but 0xe gives better results
+  // and is used by at least two other HRS3300 drivers
+  WriteRegister(static_cast<uint8_t>(Registers::PDriver), 0x6E);
+
+  // HRS and ALS both in 16-bit mode
+  WriteRegister(static_cast<uint8_t>(Registers::Res), 0x88);
+
+  // 64x gain
+  WriteRegister(static_cast<uint8_t>(Registers::Hgain), 0x10);
+}
+
+void Hrs3300::Enable() {
+  NRF_LOG_INFO("ENABLE");
+  auto value = ReadRegister(static_cast<uint8_t>(Registers::Enable));
+  value |= 0x80;
+  WriteRegister(static_cast<uint8_t>(Registers::Enable), value);
+}
+
+void Hrs3300::Disable() {
+  NRF_LOG_INFO("DISABLE");
+  auto value = ReadRegister(static_cast<uint8_t>(Registers::Enable));
+  value &= ~0x80;
+  WriteRegister(static_cast<uint8_t>(Registers::Enable), value);
+}
+
+uint16_t Hrs3300::ReadHrs() {
+  auto m = ReadRegister(static_cast<uint8_t>(Registers::C0DataM));
+  auto h = ReadRegister(static_cast<uint8_t>(Registers::C0DataH));
+  auto l = ReadRegister(static_cast<uint8_t>(Registers::C0dataL));
+  return (m << 8) | ((h & 0x0f) << 4) | (l & 0x0f) | ((l & 0x30) << 12);
+}
+
+uint16_t Hrs3300::ReadAls() {
+  auto m = ReadRegister(static_cast<uint8_t>(Registers::C1dataM));
+  auto h = ReadRegister(static_cast<uint8_t>(Registers::C1dataH));
+  auto l = ReadRegister(static_cast<uint8_t>(Registers::C1dataL));
+  return (m << 3) | ((h & 0x3f) << 11) | (l & 0x07);
+}
+
+void Hrs3300::SetGain(uint8_t gain) {
+  static constexpr uint8_t maxGain = 64;
+  gain = std::min(gain, maxGain);
+  uint8_t hgain = 0;
+  while((1 << hgain) < gain)
+    hgain++;
+
+    WriteRegister(static_cast<uint8_t>(Registers::Hgain), hgain << 2);
+}
+
+void Hrs3300::SetDrive(uint8_t drive) {
+  auto en = ReadRegister(static_cast<uint8_t>(Registers::Enable));
+  auto pd = ReadRegister(static_cast<uint8_t>(Registers::PDriver));
+
+  en = (en & 0xf7) | ((drive & 2) << 2);
+  pd = (pd & 0xbf) | ((drive & 1) << 6);
+
+  WriteRegister(static_cast<uint8_t>(Registers::Enable), en);
+  WriteRegister(static_cast<uint8_t>(Registers::PDriver), pd);
+}
+
+void Hrs3300::WriteRegister(uint8_t reg, uint8_t data) {
+  auto ret = twiMaster.Write(twiAddress, reg, &data, 1);
+  if(ret != TwiMaster::ErrorCodes::NoError)
+    NRF_LOG_INFO("WRITE ERROR");
+}
+
+uint8_t Hrs3300::ReadRegister(uint8_t reg) {
+  uint8_t value;
+  auto ret = twiMaster.Read(twiAddress, reg, &value, 1);
+  if(ret != TwiMaster::ErrorCodes::NoError)
+    NRF_LOG_INFO("READ ERROR");
+  return value;
+}
+
+
+
+
+
+
+
+
+
+
+

--- a/src/drivers/Hrs3300.cpp
+++ b/src/drivers/Hrs3300.cpp
@@ -1,3 +1,9 @@
+/*
+  SPDX-License-Identifier: LGPL-3.0-or-later
+  Original work Copyright (C) 2020 Daniel Thompson
+  C++ port Copyright (C) 2021 Jean-François Milants
+*/
+
 #include <algorithm>
 #include <nrf_gpio.h>
 #include "Hrs3300.h"
@@ -7,7 +13,9 @@
 #include <nrf_log.h>
 
 using namespace Pinetime::Drivers;
-
+/** Driver for the HRS3300 heart rate sensor.
+ * Original implementation from wasp-os : https://github.com/daniel-thompson/wasp-os/blob/master/wasp/drivers/hrs3300.py
+ */
 Hrs3300::Hrs3300(TwiMaster &twiMaster, uint8_t twiAddress) : twiMaster{twiMaster}, twiAddress{twiAddress} {
 
 }

--- a/src/drivers/Hrs3300.h
+++ b/src/drivers/Hrs3300.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "TwiMaster.h"
+
+namespace Pinetime {
+  namespace Drivers {
+    class Hrs3300 {
+    public:
+      enum class Registers : uint8_t {
+        Id = 0x00,
+        Enable = 0x01,
+        EnableHen = 0x80,
+        C1dataM = 0x08,
+        C0DataM = 0x09,
+        C0DataH = 0x0a,
+        PDriver = 0x0c,
+        C1dataH = 0x0d,
+        C1dataL = 0x0e,
+        C0dataL = 0x0f,
+        Res = 0x16,
+        Hgain = 0x17
+      };
+
+      Hrs3300(TwiMaster& twiMaster, uint8_t twiAddress);
+      Hrs3300(const Hrs3300&) = delete;
+      Hrs3300& operator=(const Hrs3300&) = delete;
+      Hrs3300(Hrs3300&&) = delete;
+      Hrs3300& operator=(Hrs3300&&) = delete;
+
+      void Init();
+      void Enable();
+      void Disable();
+      uint16_t ReadHrs();
+      uint16_t ReadAls();
+      void SetGain(uint8_t gain);
+      void SetDrive(uint8_t drive);
+
+    private:
+      TwiMaster& twiMaster;
+      uint8_t twiAddress;
+
+      void WriteRegister(uint8_t reg, uint8_t data);
+      uint8_t ReadRegister(uint8_t reg);
+
+    };
+  }
+}

--- a/src/heartratetask/HeartRateTask.cpp
+++ b/src/heartratetask/HeartRateTask.cpp
@@ -1,0 +1,89 @@
+#include "HeartRateTask.h"
+#include <drivers/Hrs3300.h>
+#include <components/heartrate/HeartRateController.h>
+#include <nrf_log.h>
+
+using namespace Pinetime::Applications;
+
+HeartRateTask::HeartRateTask(Drivers::Hrs3300 &heartRateSensor, Controllers::HeartRateController& controller) :
+      heartRateSensor{heartRateSensor},
+      controller{controller},
+      ppg{static_cast<float>(heartRateSensor.ReadHrs())} {
+  messageQueue = xQueueCreate(10, 1);
+  controller.SetHeartRateTask(this);
+}
+
+void HeartRateTask::Start() {
+  if (pdPASS != xTaskCreate(HeartRateTask::Process, "Heartrate", 500, this, 0, &taskHandle))
+    APP_ERROR_HANDLER(NRF_ERROR_NO_MEM);
+}
+
+void HeartRateTask::Process(void *instance) {
+  auto *app = static_cast<HeartRateTask *>(instance);
+  app->Work();
+}
+
+void HeartRateTask::Work() {
+  int lastBpm = 0;
+  while (true) {
+    Messages msg;
+    uint32_t delay;
+    if (state == States::Running) {
+      if (measurementStarted) delay = 40;
+      else delay = 100;
+    } else
+      delay = portMAX_DELAY;
+
+    if (xQueueReceive(messageQueue, &msg, delay)) {
+      switch (msg) {
+        case Messages::GoToSleep:
+          StopMeasurement();
+          state = States::Idle;
+          break;
+        case Messages::WakeUp:
+          state = States::Running;
+          break;
+        case Messages::StartMeasurement:
+          lastBpm = 0;
+          StartMeasurement();
+          ppg.SetOffset(heartRateSensor.ReadHrs());
+          break;
+        case Messages::StopMeasurement:
+          StopMeasurement();
+          break;
+      }
+    }
+
+    if (measurementStarted) {
+      auto hrs = heartRateSensor.ReadHrs();
+      ppg.Preprocess(hrs);
+      auto bpm = ppg.HeartRate();
+
+      if (lastBpm == 0 && bpm == 0) controller.Update(Controllers::HeartRateController::States::NoTouch, 0);
+      if(bpm != 0) {
+        lastBpm = bpm;
+        controller.Update(Controllers::HeartRateController::States::Running, lastBpm);
+      }
+    }
+  }
+}
+
+void HeartRateTask::PushMessage(HeartRateTask::Messages msg) {
+  BaseType_t xHigherPriorityTaskWoken;
+  xHigherPriorityTaskWoken = pdFALSE;
+  xQueueSendFromISR(messageQueue, &msg, &xHigherPriorityTaskWoken);
+  if (xHigherPriorityTaskWoken) {
+    /* Actual macro used here is port specific. */
+    // TODO : should I do something here?
+  }
+}
+
+void HeartRateTask::StartMeasurement() {
+  heartRateSensor.Enable();
+  measurementStarted = true;
+}
+
+void HeartRateTask::StopMeasurement() {
+  heartRateSensor.Disable();
+  measurementStarted = false;
+}

--- a/src/heartratetask/HeartRateTask.h
+++ b/src/heartratetask/HeartRateTask.h
@@ -1,0 +1,43 @@
+#pragma once
+#include <FreeRTOS.h>
+#include <task.h>
+#include <queue.h>
+#include <components/heartrate/Ppg.h>
+
+
+namespace Pinetime {
+  namespace Drivers {
+    class Hrs3300;
+  }
+  namespace Controllers{
+    class HeartRateController;
+  }
+  namespace Applications {
+    class HeartRateTask {
+    public:
+      enum class Messages : uint8_t {GoToSleep, WakeUp, StartMeasurement, StopMeasurement };
+      enum class States {Idle, Running};
+
+      explicit HeartRateTask(Drivers::Hrs3300& heartRateSensor, Controllers::HeartRateController& controller);
+      void Start();
+      void Work();
+      void PushMessage(Messages msg);
+
+    private:
+      static void Process(void* instance);
+      void StartMeasurement();
+      void StopMeasurement();
+
+      TaskHandle_t taskHandle;
+      QueueHandle_t messageQueue;
+      States state = States::Running;
+      Drivers::Hrs3300 &heartRateSensor;
+      Controllers::HeartRateController& controller;
+      Controllers::Ppg ppg;
+      bool measurementStarted = false;
+
+    };
+
+  }
+}
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,6 +25,7 @@
 #include <FreeRTOS.h>
 #include <task.h>
 #include <timers.h>
+#include <drivers/Hrs3300.h>
 
 #include "components/battery/BatteryController.h"
 #include "components/ble/BleController.h"
@@ -57,6 +58,7 @@ static constexpr uint8_t pinLcdDataCommand = 18;
 static constexpr uint8_t pinTwiScl = 7;
 static constexpr uint8_t pinTwiSda = 6;
 static constexpr uint8_t touchPanelTwiAddress = 0x15;
+static constexpr uint8_t heartRateSensorTwiAddress = 0x44;
 
 Pinetime::Drivers::SpiMaster spi{Pinetime::Drivers::SpiMaster::SpiModule::SPI0, {
         Pinetime::Drivers::SpiMaster::BitOrder::Msb_Lsb,
@@ -83,6 +85,8 @@ Pinetime::Drivers::TwiMaster twiMaster{Pinetime::Drivers::TwiMaster::Modules::TW
                                                MaxTwiFrequencyWithoutHardwareBug, pinTwiSda, pinTwiScl}};
 Pinetime::Drivers::Cst816S touchPanel {twiMaster, touchPanelTwiAddress};
 Pinetime::Components::LittleVgl lvgl {lcd, touchPanel};
+
+Pinetime::Drivers::Hrs3300 heartRateSensor {twiMaster, heartRateSensorTwiAddress};
 
 
 TimerHandle_t debounceTimer;
@@ -237,7 +241,7 @@ int main(void) {
   debounceTimer = xTimerCreate ("debounceTimer", 200, pdFALSE, (void *) 0, DebounceTimerCallback);
 
   systemTask.reset(new Pinetime::System::SystemTask(spi, lcd, spiNorFlash, twiMaster, touchPanel, lvgl, batteryController, bleController,
-                                                    dateTimeController, notificationManager));
+                                                    dateTimeController, notificationManager, heartRateSensor));
   systemTask->Start();
   nimble_port_init();
 

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -44,6 +44,7 @@ SystemTask::SystemTask(Drivers::SpiMaster &spi, Drivers::St7789 &lcd,
                        Pinetime::Drivers::Hrs3300& heartRateSensor) :
                        spi{spi}, lcd{lcd}, spiNorFlash{spiNorFlash},
                        twiMaster{twiMaster}, touchPanel{touchPanel}, lvgl{lvgl}, batteryController{batteryController},
+                       heartRateController{*this},
                        bleController{bleController}, dateTimeController{dateTimeController},
                        watchdog{}, watchdogView{watchdog}, notificationManager{notificationManager},
                        nimbleController(*this, bleController,dateTimeController, notificationManager, batteryController, spiNorFlash),
@@ -193,6 +194,12 @@ void SystemTask::Work() {
           twiMaster.Sleep();
           isSleeping = true;
           isGoingToSleep = false;
+          break;
+        case Messages::HeartRateRunning:
+          doNotGoToSleep = true;
+          break;
+        case Messages::HeartRateStopped:
+          doNotGoToSleep = false;
           break;
         default: break;
       }

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -21,6 +21,7 @@
 #include "drivers/SpiMaster.h"
 #include "drivers/SpiNorFlash.h"
 #include "drivers/TwiMaster.h"
+#include "drivers/Hrs3300.h"
 #include "main.h"
 
 using namespace Pinetime::System;
@@ -39,12 +40,14 @@ SystemTask::SystemTask(Drivers::SpiMaster &spi, Drivers::St7789 &lcd,
                        Components::LittleVgl &lvgl,
                        Controllers::Battery &batteryController, Controllers::Ble &bleController,
                        Controllers::DateTime &dateTimeController,
-                       Pinetime::Controllers::NotificationManager& notificationManager) :
+                       Pinetime::Controllers::NotificationManager& notificationManager,
+                       Pinetime::Drivers::Hrs3300& heartRateSensor) :
                        spi{spi}, lcd{lcd}, spiNorFlash{spiNorFlash},
                        twiMaster{twiMaster}, touchPanel{touchPanel}, lvgl{lvgl}, batteryController{batteryController},
                        bleController{bleController}, dateTimeController{dateTimeController},
                        watchdog{}, watchdogView{watchdog}, notificationManager{notificationManager},
-                       nimbleController(*this, bleController,dateTimeController, notificationManager, batteryController, spiNorFlash) {
+                       nimbleController(*this, bleController,dateTimeController, notificationManager, batteryController, spiNorFlash),
+                       heartRateSensor{heartRateSensor}{
   systemTasksMsgQueue = xQueueCreate(10, 1);
 }
 
@@ -77,11 +80,18 @@ void SystemTask::Work() {
   batteryController.Init();
 
   displayApp.reset(new Pinetime::Applications::DisplayApp(lcd, lvgl, touchPanel, batteryController, bleController,
-                                                          dateTimeController, watchdogView, *this, notificationManager));
+                                                          dateTimeController, watchdogView, *this, notificationManager, heartRateController));
   displayApp->Start();
 
   batteryController.Update();
   displayApp->PushMessage(Pinetime::Applications::DisplayApp::Messages::UpdateBatteryLevel);
+
+
+  heartRateSensor.Init();
+  heartRateSensor.Disable();
+  heartRateApp.reset(new Pinetime::Applications::HeartRateTask(heartRateSensor, heartRateController));
+  heartRateApp->Start();
+
 
   nrf_gpio_cfg_sense_input(pinButton, (nrf_gpio_pin_pull_t)GPIO_PIN_CNF_PULL_Pulldown, (nrf_gpio_pin_sense_t)GPIO_PIN_CNF_SENSE_High);
   nrf_gpio_cfg_output(15);

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -47,8 +47,8 @@ SystemTask::SystemTask(Drivers::SpiMaster &spi, Drivers::St7789 &lcd,
                        heartRateController{*this},
                        bleController{bleController}, dateTimeController{dateTimeController},
                        watchdog{}, watchdogView{watchdog}, notificationManager{notificationManager},
-                       nimbleController(*this, bleController,dateTimeController, notificationManager, batteryController, spiNorFlash),
-                       heartRateSensor{heartRateSensor}{
+                       heartRateSensor{heartRateSensor},
+                       nimbleController(*this, bleController,dateTimeController, notificationManager, batteryController, spiNorFlash, heartRateController) {
   systemTasksMsgQueue = xQueueCreate(10, 1);
 }
 

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -141,6 +141,7 @@ void SystemTask::Work() {
 
           displayApp->PushMessage(Applications::DisplayApp::Messages::GoToRunning);
           displayApp->PushMessage(Applications::DisplayApp::Messages::UpdateBatteryLevel);
+          heartRateApp->PushMessage(Pinetime::Applications::HeartRateTask::Messages::WakeUp);
 
           isSleeping = false;
           isWakingUp = false;
@@ -150,6 +151,7 @@ void SystemTask::Work() {
           NRF_LOG_INFO("[systemtask] Going to sleep");
           xTimerStop(idleTimer, 0);
           displayApp->PushMessage(Pinetime::Applications::DisplayApp::Messages::GoToSleep);
+          heartRateApp->PushMessage(Pinetime::Applications::HeartRateTask::Messages::GoToSleep);
           break;
         case Messages::OnNewTime:
           ReloadIdleTimer();
@@ -194,12 +196,6 @@ void SystemTask::Work() {
           twiMaster.Sleep();
           isSleeping = true;
           isGoingToSleep = false;
-          break;
-        case Messages::HeartRateRunning:
-          doNotGoToSleep = true;
-          break;
-        case Messages::HeartRateStopped:
-          doNotGoToSleep = false;
           break;
         default: break;
       }

--- a/src/systemtask/SystemTask.h
+++ b/src/systemtask/SystemTask.h
@@ -74,8 +74,8 @@ namespace Pinetime {
         Pinetime::Drivers::Watchdog watchdog;
         Pinetime::Drivers::WatchdogView watchdogView;
         Pinetime::Controllers::NotificationManager& notificationManager;
-        Pinetime::Controllers::NimbleController nimbleController;
         Pinetime::Drivers::Hrs3300& heartRateSensor;
+        Pinetime::Controllers::NimbleController nimbleController;
 
         static constexpr uint8_t pinSpiSck = 2;
         static constexpr uint8_t pinSpiMosi = 3;

--- a/src/systemtask/SystemTask.h
+++ b/src/systemtask/SystemTask.h
@@ -5,6 +5,8 @@
 #include <FreeRTOS.h>
 #include <task.h>
 #include <timers.h>
+#include <heartratetask/HeartRateTask.h>
+#include <components/heartrate/HeartRateController.h>
 
 #include "SystemMonitor.h"
 #include "components/battery/BatteryController.h"
@@ -20,6 +22,7 @@ namespace Pinetime {
     class SpiNorFlash;
     class St7789;
     class TwiMaster;
+    class Hrs3300;
   }
   namespace System {
     class SystemTask {
@@ -34,7 +37,8 @@ namespace Pinetime {
                    Components::LittleVgl &lvgl,
                    Controllers::Battery &batteryController, Controllers::Ble &bleController,
                    Controllers::DateTime &dateTimeController,
-                   Pinetime::Controllers::NotificationManager& manager);
+                   Pinetime::Controllers::NotificationManager& manager,
+                   Pinetime::Drivers::Hrs3300& heartRateSensor);
 
 
         void Start();
@@ -58,6 +62,9 @@ namespace Pinetime {
         Pinetime::Components::LittleVgl& lvgl;
         Pinetime::Controllers::Battery& batteryController;
         std::unique_ptr<Pinetime::Applications::DisplayApp> displayApp;
+        Pinetime::Controllers::HeartRateController heartRateController;
+        std::unique_ptr<Pinetime::Applications::HeartRateTask> heartRateApp;
+
         Pinetime::Controllers::Ble& bleController;
         Pinetime::Controllers::DateTime& dateTimeController;
         QueueHandle_t systemTasksMsgQueue;
@@ -68,7 +75,7 @@ namespace Pinetime {
         Pinetime::Drivers::WatchdogView watchdogView;
         Pinetime::Controllers::NotificationManager& notificationManager;
         Pinetime::Controllers::NimbleController nimbleController;
-
+        Pinetime::Drivers::Hrs3300& heartRateSensor;
 
         static constexpr uint8_t pinSpiSck = 2;
         static constexpr uint8_t pinSpiMosi = 3;

--- a/src/systemtask/SystemTask.h
+++ b/src/systemtask/SystemTask.h
@@ -28,8 +28,7 @@ namespace Pinetime {
     class SystemTask {
       public:
         enum class Messages {GoToSleep, GoToRunning, OnNewTime, OnNewNotification, BleConnected,
-            BleFirmwareUpdateStarted, BleFirmwareUpdateFinished, OnTouchEvent, OnButtonEvent, OnDisplayTaskSleeping,
-          HeartRateRunning, HeartRateStopped
+            BleFirmwareUpdateStarted, BleFirmwareUpdateFinished, OnTouchEvent, OnButtonEvent, OnDisplayTaskSleeping
         };
 
         SystemTask(Drivers::SpiMaster &spi, Drivers::St7789 &lcd,

--- a/src/systemtask/SystemTask.h
+++ b/src/systemtask/SystemTask.h
@@ -28,7 +28,8 @@ namespace Pinetime {
     class SystemTask {
       public:
         enum class Messages {GoToSleep, GoToRunning, OnNewTime, OnNewNotification, BleConnected,
-            BleFirmwareUpdateStarted, BleFirmwareUpdateFinished, OnTouchEvent, OnButtonEvent, OnDisplayTaskSleeping
+            BleFirmwareUpdateStarted, BleFirmwareUpdateFinished, OnTouchEvent, OnButtonEvent, OnDisplayTaskSleeping,
+          HeartRateRunning, HeartRateStopped
         };
 
         SystemTask(Drivers::SpiMaster &spi, Drivers::St7789 &lcd,


### PR DESCRIPTION
This PR adds support for the HRS3300 heart rate sensor. It's based on an open source implementation of the low-level driver and algorithm from [wasp-os](https://github.com/daniel-thompson/wasp-os) (thanks to [Daniel](https://github.com/daniel-thompson) for this great work!).

A new app is available in the menu and allows to start/stop the HR acquisition and displays the HR value.
A new BLE service (Heart Rate service) has been added and implements the standard BLE heart rate service.

Video : https://video.codingfield.com/videos/watch/63a5d374-f911-4eb5-88a1-4ee184205675

![image](https://user-images.githubusercontent.com/2261652/104847888-ab04be00-58e2-11eb-8401-d43b7bdfd4d4.png)
