### PR TITLE
Fix bug in animation management for lv_label

### DIFF
--- a/src/libs/lvgl/patches/0002-fix_bug_in_animation_management_for_lv_label.patch
+++ b/src/libs/lvgl/patches/0002-fix_bug_in_animation_management_for_lv_label.patch
@@ -1,0 +1,51 @@
+Index: src/libs/lvgl/src/lv_misc/lv_anim.c
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/src/libs/lvgl/src/lv_misc/lv_anim.c b/src/libs/lvgl/src/lv_misc/lv_anim.c
+--- a/src/libs/lvgl/src/lv_misc/lv_anim.c	(revision 12a3b6cc8ec1fd6b951c353ab3a5fbbb9934fdd4)
++++ b/src/libs/lvgl/src/lv_misc/lv_anim.c	(date 1610901672072)
+@@ -158,12 +158,12 @@
+  * @param end end value of the animation
+  * @return the required time [ms] for the animation with the given parameters
+  */
+-uint16_t lv_anim_speed_to_time(uint16_t speed, lv_anim_value_t start, lv_anim_value_t end)
++uint32_t lv_anim_speed_to_time(uint16_t speed, lv_anim_value_t start, lv_anim_value_t end)
+ {
+     int32_t d     = LV_MATH_ABS((int32_t)start - end);
+     uint32_t time = (int32_t)((int32_t)(d * 1000) / speed);
+ 
+-    if(time > UINT16_MAX) time = UINT16_MAX;
++    if(time > UINT32_MAX) time = UINT32_MAX;
+ 
+     if(time == 0) {
+         time++;
+Index: src/libs/lvgl/src/lv_misc/lv_anim.h
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/src/libs/lvgl/src/lv_misc/lv_anim.h b/src/libs/lvgl/src/lv_misc/lv_anim.h
+--- a/src/libs/lvgl/src/lv_misc/lv_anim.h	(revision 12a3b6cc8ec1fd6b951c353ab3a5fbbb9934fdd4)
++++ b/src/libs/lvgl/src/lv_misc/lv_anim.h	(date 1610901672076)
+@@ -73,8 +73,8 @@
+     lv_anim_ready_cb_t ready_cb; /**< Call it when the animation is ready*/
+     int32_t start;               /**< Start value*/
+     int32_t end;                 /**< End value*/
+-    uint16_t time;               /**< Animation time in ms*/
+-    int16_t act_time;            /**< Current time in animation. Set to negative to make delay.*/
++    uint32_t time;               /**< Animation time in ms*/
++    int32_t act_time;            /**< Current time in animation. Set to negative to make delay.*/
+     uint16_t playback_pause;     /**< Wait before play back*/
+     uint16_t repeat_pause;       /**< Wait before repeat*/
+ #if LV_USE_USER_DATA
+@@ -266,7 +266,7 @@
+  * @param end end value of the animation
+  * @return the required time [ms] for the animation with the given parameters
+  */
+-uint16_t lv_anim_speed_to_time(uint16_t speed, lv_anim_value_t start, lv_anim_value_t end);
++uint32_t lv_anim_speed_to_time(uint16_t speed, lv_anim_value_t start, lv_anim_value_t end);
+ 
+ /**
+  * Calculate the current value of an animation applying linear characteristic

--- a/src/libs/lvgl/src/lv_misc/lv_anim.c
+++ b/src/libs/lvgl/src/lv_misc/lv_anim.c
@@ -158,12 +158,12 @@ uint16_t lv_anim_count_running(void)
  * @param end end value of the animation
  * @return the required time [ms] for the animation with the given parameters
  */
-uint16_t lv_anim_speed_to_time(uint16_t speed, lv_anim_value_t start, lv_anim_value_t end)
+uint32_t lv_anim_speed_to_time(uint16_t speed, lv_anim_value_t start, lv_anim_value_t end)
 {
     int32_t d     = LV_MATH_ABS((int32_t)start - end);
     uint32_t time = (int32_t)((int32_t)(d * 1000) / speed);
 
-    if(time > UINT16_MAX) time = UINT16_MAX;
+    if(time > UINT32_MAX) time = UINT32_MAX;
 
     if(time == 0) {
         time++;

--- a/src/libs/lvgl/src/lv_misc/lv_anim.h
+++ b/src/libs/lvgl/src/lv_misc/lv_anim.h
@@ -73,8 +73,8 @@ typedef struct _lv_anim_t
     lv_anim_ready_cb_t ready_cb; /**< Call it when the animation is ready*/
     int32_t start;               /**< Start value*/
     int32_t end;                 /**< End value*/
-    uint16_t time;               /**< Animation time in ms*/
-    int16_t act_time;            /**< Current time in animation. Set to negative to make delay.*/
+    uint32_t time;               /**< Animation time in ms*/
+    int32_t act_time;            /**< Current time in animation. Set to negative to make delay.*/
     uint16_t playback_pause;     /**< Wait before play back*/
     uint16_t repeat_pause;       /**< Wait before repeat*/
 #if LV_USE_USER_DATA
@@ -266,7 +266,7 @@ uint16_t lv_anim_count_running(void);
  * @param end end value of the animation
  * @return the required time [ms] for the animation with the given parameters
  */
-uint16_t lv_anim_speed_to_time(uint16_t speed, lv_anim_value_t start, lv_anim_value_t end);
+uint32_t lv_anim_speed_to_time(uint16_t speed, lv_anim_value_t start, lv_anim_value_t end);
 
 /**
  * Calculate the current value of an animation applying linear characteristic


### PR DESCRIPTION
In #152 and #163 , we noticed that the scrolling animation for labels was not working properly (text was scrolling really fast even with low specific speed, truncated strings,...).

According to [this link](https://forum.lvgl.io/t/animation-lv-label-long-sroll-lv-label-long-sroll-circ-stop-for-large-strings/1802), there is a bug related to animation speed in lvgl < 7.

I changed the animation time to uint16_t to uint32_t and tested with #163  : the whole text is displayed and the speed is not erratic anymore.

The patch is applied directly to the LVGL code (because the code is not a submodule, it's copied into this repo), and the .patch file contains the changes that were applied.