### PR TITLE
Fix config file discrepancy

### DIFF
--- a/doc/openOCD.md
+++ b/doc/openOCD.md
@@ -89,12 +89,12 @@ reset
 ## Examples
 ### Flash bootloader and application
 ```
-openocd -f ./openocd-stlink.cfg -f ./flash_bootloader_app.ocd
+openocd -f ./openocd-stlink.ocd -f ./flash_bootloader_app.ocd
 ```
 
 ### Flash graphics flasher
 ```
-openocd -f ./openocd-stlink.cfg -f ./flash_graphics.ocd
+openocd -f ./openocd-stlink.ocd -f ./flash_graphics.ocd
 ```
 
 ## Connect the STLinkV2 to the PineTime


### PR DESCRIPTION
Fixes a discrepancy with config file naming. The config files it tells you to create end in ocd, but the example flash command uses a filename ending in cfg