### PR TITLE
changed command MemoryDataAccessControl from 036 to 0x36 in St7789 class

### DIFF
--- a/src/drivers/St7789.h
+++ b/src/drivers/St7789.h
@@ -58,7 +58,7 @@ namespace Pinetime {
           ColumnAddressSet = 0x2a,
           RowAddressSet = 0x2b,
           WriteToRam = 0x2c,
-          MemoryDataAccessControl = 036,
+          MemoryDataAccessControl = 0x36,
           VerticalScrollDefinition = 0x33,
           VerticalScrollStartAddress = 0x37,
           ColMod = 0x3a,


### PR DESCRIPTION
Fixed minor error in commands enum for class St7789. The MemoryDataAccessControl was mistakenly set to `036` and should be `0x36`. 

I have built and run the app on my test PineTime but unsure how to do further validation and not sure why it wan't an issue (as `0x1E` is not a valid command) in the first place without doing further investigation.