### PR TITLE
Create .gitconfig

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,5 @@
+[core]
+    whitespace = blank-at-eol,blank-at-eof,space-before-tab
+    autocrlf = input
+[apply]
+    whitespace = fix


### PR DESCRIPTION
This file instructs git to:
* `blank-at-eol` looks for spaces at the end of a line
* `blank-at-eof` notices blank lines at the end of a file
* `space-before-tab` looks for spaces before tabs at the beginning of a line
* `fix` outputs warnings for a few such errors, and applies the patch after fixing them (strip is a synonym --- the tool used to consider only trailing whitespace characters as errors, and the fix involved stripping them, but modern Gits do more)
* `autocrlf = input` converts CRLF to LF on commit but not the other way around