### PR TITLE
Enabled clang-format in Clion

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -27,5 +27,8 @@
         <option name="KEEP_INDENTS_ON_EMPTY_LINES" value="true" />
       </indentOptions>
     </codeStyleSettings>
+    <clangFormatSettings>
+      <option name="ENABLED" value="true" />
+    </clangFormatSettings>
   </code_scheme>
 </component>


### PR DESCRIPTION
This PR enables clang-format automatically in Clion, it depends on https://github.com/JF002/Pinetime/pull/194