### PR TITLE
refactored class DirtyValue

### DIFF
--- a/src/displayapp/screens/Clock.h
+++ b/src/displayapp/screens/Clock.h
@@ -21,11 +21,10 @@ namespace Pinetime {
       template <class T>
       class DirtyValue {
         public:
-          explicit DirtyValue(T v) { value = v; }
-          explicit DirtyValue(T& v) { value = v; }
+          DirtyValue() = default;                      // Use NSDMI
+          explicit DirtyValue(T const& v):value{v}{}   // Use MIL and const-lvalue-ref
           bool IsUpdated() const { return isUpdated; }
-          T& Get() { this->isUpdated = false; return value; }
-
+          T const& Get() { this->isUpdated = false; return value; }  // never expose a non-const lvalue-ref
           DirtyValue& operator=(const T& other) {
             if (this->value != other) {
               this->value = other;
@@ -34,9 +33,10 @@ namespace Pinetime {
             return *this;
           }
         private:
-          T value;
-          bool isUpdated = true;
+          T value{};            // NSDMI - default initialise type
+          bool isUpdated{true}; // NSDMI - use brace initilisation
       };
+
       class Clock : public Screen {
         public:
           Clock(DisplayApp* app,
@@ -64,13 +64,13 @@ namespace Pinetime {
           Pinetime::Controllers::DateTime::Days currentDayOfWeek = Pinetime::Controllers::DateTime::Days::Unknown;
           uint8_t currentDay = 0;
 
-          DirtyValue<int> batteryPercentRemaining  {0};
-          DirtyValue<bool> bleState {false};
-          DirtyValue<std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>> currentDateTime;
-          DirtyValue<uint32_t> stepCount  {0};
-          DirtyValue<uint8_t> heartbeat  {0};
-          DirtyValue<bool> heartbeatRunning  {false};
-          DirtyValue<bool> notificationState {false};
+          DirtyValue<int> batteryPercentRemaining  {};
+          DirtyValue<bool> bleState {};
+          DirtyValue<std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>> currentDateTime{};
+          DirtyValue<uint32_t> stepCount  {};
+          DirtyValue<uint8_t> heartbeat  {};
+          DirtyValue<bool> heartbeatRunning  {};
+          DirtyValue<bool> notificationState {};
 
           lv_obj_t* label_time;
           lv_obj_t* label_date;


### PR DESCRIPTION
# class DirtyValue refactor
Reworking of class DirtyValue inClock.h 

## Constructors 
It makes no sense to have both a non-const lvalue-reference constructor overloaded with an rvalue-reference constructor.  You’ll only ever call the rvalue based on temporary objects and a const-lvalue-ref will also bind to an rvalue.

In addition, there is no ability to create a DirtyValue object without supplying an initialisation value forcing constructors to always take a value.

Finally, the Member-Initialisation-List (MIL) should always be used for value-initialisation  rather than using copy-assignment in the body of a constructor.

Proposed change:
Create default constructor and use NSMDI for type default initialisation
Replace lvalue and rvalue constructors with single const-lvalue-reference constructor
Use MIL for value initialisation
```
  DirtyValue() = default;                      // Use NSDMI
  explicit DirtyValue(T const& v):value{v}{}   // Use MIL and const-lvalue-ref
```
## Get member function
The current Get() return a non-const reference to an internal, private member. This is considered bad practice as it allows modification of the private value via the reference without using the op=() function (see 
[Standard C++](https://isocpp.org/wiki/faq/const-correctness#return-const-ref-from-const-memfn) )

Proposed change:
```
  T const& Get()
```

## Member initialisation
Bring the code inline with modern style by utilising Non-Static Data Member Initialisation (NSDMI)

Proposed change:
```
private:
  T value{};            // NSDMI - default initialise type
  bool isUpdated{true}; // NSDMI - use brace initilisation
```
For detail comparison see:
[Compiler Explorer](https://godbolt.org/z/Kro3e4)


