### PR TITLE
Flash correct file name

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -831,7 +831,7 @@ if (USE_JLINK)
             COMMAND ${NRFJPROG} --program ${EXECUTABLE_FILE_NAME}.hex -f ${NRF_TARGET} --sectorerase
             COMMAND sleep 0.5s
             COMMAND ${NRFJPROG} --reset -f ${NRF_TARGET}
-            COMMENT "flashing ${EXECUTABLE_NAME}.hex"
+            COMMENT "flashing ${EXECUTABLE_FILE_NAME}.hex"
             )
 
 elseif (USE_GDB_CLIENT)
@@ -841,8 +841,8 @@ elseif (USE_GDB_CLIENT)
             )
     add_custom_target("FLASH_${EXECUTABLE_NAME}"
             DEPENDS ${EXECUTABLE_NAME}
-            COMMAND ${GDB_CLIENT_BIN_PATH} -nx --batch -ex 'target extended-remote ${GDB_CLIENT_TARGET_REMOTE}' -ex 'monitor swdp_scan' -ex 'attach 1' -ex 'load' -ex 'kill' ${EXECUTABLE_NAME}.hex
-            COMMENT "flashing ${EXECUTABLE_NAME}.hex"
+            COMMAND ${GDB_CLIENT_BIN_PATH} -nx --batch -ex 'target extended-remote ${GDB_CLIENT_TARGET_REMOTE}' -ex 'monitor swdp_scan' -ex 'attach 1' -ex 'load' -ex 'kill' ${EXECUTABLE_FILE_NAME}.hex
+            COMMENT "flashing ${EXECUTABLE_FILE_NAME}.hex"
             )
 elseif (USE_OPENOCD)
     if (USE_CMSIS_DAP)
@@ -867,10 +867,10 @@ elseif (USE_OPENOCD)
                 -c 'transport select swd'
                 -c 'source [find target/nrf52.cfg]'
                 -c 'halt'
-                -c "program \"${EXECUTABLE_NAME}.hex\""
+                -c "program \"${EXECUTABLE_FILE_NAME}.hex\""
                 -c 'reset'
                 -c 'shutdown'
-                COMMENT "flashing ${EXECUTABLE_NAME}.hex"
+                COMMENT "flashing ${EXECUTABLE_BIN_NAME}.hex"
                 )
     else ()
         add_custom_target(FLASH_ERASE
@@ -879,8 +879,8 @@ elseif (USE_OPENOCD)
                 )
         add_custom_target("FLASH_${EXECUTABLE_NAME}"
                 DEPENDS ${EXECUTABLE_NAME}
-                COMMAND ${OPENOCD_BIN_PATH} -c "tcl_port disabled" -c "gdb_port 3333" -c "telnet_port 4444" -f interface/stlink.cfg -c 'transport select hla_swd' -f target/nrf52.cfg -c "program \"${EXECUTABLE_NAME}.hex\"" -c reset -c shutdown
-                COMMENT "flashing ${EXECUTABLE_NAME}.hex"
+                COMMAND ${OPENOCD_BIN_PATH} -c "tcl_port disabled" -c "gdb_port 3333" -c "telnet_port 4444" -f interface/stlink.cfg -c 'transport select hla_swd' -f target/nrf52.cfg -c "program \"${EXECUTABLE_FILE_NAME}.hex\"" -c reset -c shutdown
+                COMMENT "flashing ${EXECUTABLE_FILE_NAME}.hex"
                 )
     endif ()
 endif ()


### PR DESCRIPTION
Currently, trying to flash the firmware with `make FLASH_pinetime-app` fails because it's trying to flash `pinetime-app.hex`, which doesn't exist. The correct filename is `pinetime-app-0.13.0.hex`, which can be found in the EXECUTABLE_FILE_NAME variable.